### PR TITLE
Changed constructor of User

### DIFF
--- a/common/src/main/java/me/lucko/luckperms/users/User.java
+++ b/common/src/main/java/me/lucko/luckperms/users/User.java
@@ -62,13 +62,13 @@ public abstract class User extends PermissionHolder implements Identifiable<User
     @Setter
     private String primaryGroup = null;
 
-    User(UUID uuid, LuckPermsPlugin plugin) {
+    public User(UUID uuid, LuckPermsPlugin plugin) {
         super(uuid.toString(), plugin);
         this.uuid = uuid;
         this.name = null;
     }
 
-    User(UUID uuid, String name, LuckPermsPlugin plugin) {
+    public User(UUID uuid, String name, LuckPermsPlugin plugin) {
         super(uuid.toString(), plugin);
         this.uuid = uuid;
         this.name = name;


### PR DESCRIPTION
User is a abstract class, and to use it in any package (like a StandaloneUserManager) i need to have access from outside to the constructor

User can still be abstrct, to sign hey you souldn't make a instance of me for api users
but could be created for standalone programs (like mine)