### PR TITLE
help tame mysql connection settings

### DIFF
--- a/common/src/main/java/me/lucko/luckperms/common/storage/backing/MySQLBacking.java
+++ b/common/src/main/java/me/lucko/luckperms/common/storage/backing/MySQLBacking.java
@@ -32,6 +32,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.concurrent.TimeUnit;
 
 public class MySQLBacking extends SQLBacking {
 
@@ -76,8 +77,10 @@ public class MySQLBacking extends SQLBacking {
         config.addDataSourceProperty("cacheServerConfiguration", true);
         config.addDataSourceProperty("elideSetAutoCommits", true);
         config.addDataSourceProperty("useLocalSessionState", true);
-        config.setConnectionTimeout(10000); // 10 seconds
-        config.setLeakDetectionThreshold(5000); // 5 seconds
+        config.setConnectionTimeout(TimeUnit.SECONDS.toMillis(10)); // 10000
+        config.setLeakDetectionThreshold(TimeUnit.SECONDS.toMillis(5)); // 5000
+        config.setValidationTimeout(TimeUnit.SECONDS.toMillis(3)); // 3000
+        config.setConnectionTestQuery("/* LuckPerms ping */ SELECT 1");
 
         hikari = new HikariDataSource(config);
 


### PR DESCRIPTION
this commit further helps tame the mysql connection pool (and really
reconnecting to the pool even when the underlying db goes down) further
from commit: 31a597c

helps in the case of #81 

this sets up `setValidationTimeout`, and `setConnectionTestQuery`
in order to better (more speedily(?)/fastly(?)/<other adective>ly(?))
handle connection timeouts in a timely manner. (although admittedly
this is already handeled well imo with the cache). however, it could
be better :tm:.

in order to do this I did the following things:
  1. Switch to `TimeUnit.SECONDS.toMillis` instead of manually entering
     milliseconds, and having the time in seconds as a comment. just
     makes it more readable imo. if you want me to change it back I can
     I'm not like attached to this or anything.
  2. Perform more common validation timeouts with `setValidationTimeout`
     this allows us to potentially bump back up the connection timeout
     (although I see no harm leaving it where it is), although allows
     us to still "fail-fast" in a way when doing validations.
  3. Use `setConnectionTestQuery` for people who somehow someway
     may not be using a JDBC4 compliant driver.