### PR TITLE
YAML/JSON batch permission defining

### DIFF
--- a/common/src/main/java/me/lucko/luckperms/common/storage/backing/JSONBacking.java
+++ b/common/src/main/java/me/lucko/luckperms/common/storage/backing/JSONBacking.java
@@ -34,6 +34,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 
+import java.util.Iterator;
 import me.lucko.luckperms.api.HeldPermission;
 import me.lucko.luckperms.api.Node;
 import me.lucko.luckperms.api.context.ImmutableContextSet;
@@ -548,7 +549,15 @@ public class JSONBacking extends FlatfileBacking {
                 context = NodeModel.deserializeContextSet(contexts).makeImmutable();
             }
 
-            nodes.add(NodeModel.of(permission, value, server, world, expiry, context));
+            final JsonElement batchAttribute = attributes.get("permissions");
+            if (permission.startsWith("luckperms.batch") && batchAttribute != null && batchAttribute.isJsonArray()) {
+                for (JsonElement element : batchAttribute.getAsJsonArray()) {
+                    nodes.add(NodeModel.of(element.getAsString(), value, server, world, expiry, context));
+                }
+            } else {
+                nodes.add(NodeModel.of(permission, value, server, world, expiry, context));
+            }
+
         }
 
         return nodes;

--- a/common/src/main/java/me/lucko/luckperms/common/storage/backing/JSONBacking.java
+++ b/common/src/main/java/me/lucko/luckperms/common/storage/backing/JSONBacking.java
@@ -33,7 +33,6 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
-import com.google.gson.JsonPrimitive;
 
 import me.lucko.luckperms.api.HeldPermission;
 import me.lucko.luckperms.api.Node;

--- a/common/src/main/java/me/lucko/luckperms/common/storage/backing/JSONBacking.java
+++ b/common/src/main/java/me/lucko/luckperms/common/storage/backing/JSONBacking.java
@@ -33,8 +33,8 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonPrimitive;
 
-import java.util.Iterator;
 import me.lucko.luckperms.api.HeldPermission;
 import me.lucko.luckperms.api.Node;
 import me.lucko.luckperms.api.context.ImmutableContextSet;

--- a/common/src/main/java/me/lucko/luckperms/common/storage/backing/YAMLBacking.java
+++ b/common/src/main/java/me/lucko/luckperms/common/storage/backing/YAMLBacking.java
@@ -556,7 +556,15 @@ public class YAMLBacking extends FlatfileBacking {
                     context = map.build();
                 }
 
-                nodes.add(NodeModel.of(permission, value, server, world, expiry, ImmutableContextSet.fromMultimap(context)));
+                if (permission.startsWith("luckperms.batch") && attributes.get("permissions") instanceof List) {
+                    final List<String> batchPerms = (List<String>) attributes.get("permissions");
+                    for (String rawPerm : batchPerms) {
+                        nodes.add(NodeModel.of(rawPerm, value, server, world, expiry, ImmutableContextSet.fromMultimap(context)));
+                    }
+                } else {
+                    nodes.add(NodeModel.of(permission, value, server, world, expiry, ImmutableContextSet.fromMultimap(context)));
+                }
+
             }
         }
 


### PR DESCRIPTION
Makes it easier for manually defining a lot of permissions which all share the same value, context, server, world, etc.