### PR TITLE
Use single quotes in escapeStringForSql

### DIFF
--- a/common/src/main/java/me/lucko/luckperms/common/bulkupdate/BulkUpdate.java
+++ b/common/src/main/java/me/lucko/luckperms/common/bulkupdate/BulkUpdate.java
@@ -138,7 +138,7 @@ public class BulkUpdate {
             // ignored
         }
 
-        return "\"" + s + "\"";
+        return "'" + s + "'";
     }
 
 }


### PR DESCRIPTION
[StackOverflow - What is the difference between single and double quotes in SQL?](https://stackoverflow.com/questions/1992314/what-is-the-difference-between-single-and-double-quotes-in-sql)

It was causing errors like `org.h2.jdbc.JdbcSQLException: Column "someperm" not found; SQL statement: DELETE FROM luckperms_group_permissions WHERE permission = "someperm";`