### PR TITLE
Cleanup comments

### DIFF
--- a/bukkit/src/main/resources/config.yml
+++ b/bukkit/src/main/resources/config.yml
@@ -243,8 +243,7 @@ vault-debug: false
 # If your MySQL server supports it, the "mariadb" option is preferred over "mysql".
 storage-method: h2
 
-# When using a file-based storage type, LuckPerms can monitor the data files for changes, and then
-# schedule automatic updates when changes are detected.
+# When using a file-based storage type, LuckPerms can monitor the data files for changes, and then schedule automatic updates when changes are detected.
 #
 # If you don't want this to happen, set this option to false.
 watch-files: true
@@ -275,27 +274,21 @@ data:
   pool-settings:
 
     # Sets the maximum size of the MySQL connection pool.
-    # Basically this value will determine the maximum number of actual
-    # connections to the database backend.
+    # Basically this value will determine the maximum number of actual connections to the database backend.
     #
-    # More information about determining the size of connection pools can be found here:
-    # https://github.com/brettwooldridge/HikariCP/wiki/About-Pool-Sizing
+    # More information about determining the size of connection pools can be found here: https://github.com/brettwooldridge/HikariCP/wiki/About-Pool-Sizing
     maximum-pool-size: 10
 
     # Sets the minimum number of idle connections that the pool will try to maintain.
     #
-    # For maximum performance and responsiveness to spike demands, it is recommended to not set
-    # this value and instead allow the pool to act as a fixed size connection pool.
-    # (set this value to the same as 'maximum-pool-size')
+    # For maximum performance and responsiveness to spike demands, it is recommended to not set this value and instead allow the pool to act as a fixed size connection pool. (set this value to the same as 'maximum-pool-size')
     minimum-idle: 10
 
     # This setting controls the maximum lifetime of a connection in the pool in milliseconds.
-    # The value should be at least 30 seconds less than any database or infrastructure imposed
-    # connection time limit.
+    # The value should be at least 30 seconds less than any database or infrastructure imposed connection time limit.
     maximum-lifetime: 1800000 # 30 minutes
 
-    # This setting controls the maximum number of milliseconds that the plugin will wait for a
-    # connection from the pool, before timing out.
+    # This setting controls the maximum number of milliseconds that the plugin will wait for a connection from the pool, before timing out.
     connection-timeout: 5000 # 5 seconds
 
     # This setting allows you to define extra properties for connections.
@@ -303,41 +296,32 @@ data:
       useUnicode: true
       characterEncoding: utf8
 
-  # The prefix for all LuckPerms tables. Change this is you want to use different tables for
-  # different servers.
+  # The prefix for all LuckPerms tables. Change this is you want to use different tables for different servers.
   #
-  # This should *not* be set to "lp_" if you have previously ran LuckPerms v2.16.81 or earlier with
-  # this database.
+  # This should *not* be set to "lp_" if you have previously ran LuckPerms v2.16.81 or earlier with this database.
   table_prefix: 'luckperms_'
 
-  # The prefix to use for all LuckPerms collections. Change this if you want to use different
-  # collections for different servers. The default is no prefix.
+  # The prefix to use for all LuckPerms collections. Change this if you want to use different collections for different servers. The default is no prefix.
   mongodb_collection_prefix: ''
 
   # This option controls how frequently LuckPerms will perform a sync task.
-  # A sync task will refresh all data from the storage, and ensure that the most up-to-date data is
-  # being used by the plugin.
+  # A sync task will refresh all data from the storage, and ensure that the most up-to-date data is being used by the plugin.
   #
-  # This is disabled by default, as most users will not need it. However, if you're using a remote
-  # storage type without a messaging service setup, you may wish to set this value to something like
-  # 3.
+  # This is disabled by default, as most users will not need it. However, if you're using a remote storage type without a messaging service setup, you may wish to set this value to something like 3.
   #
   # Set to -1 to disable the task completely.
   sync-minutes: -1
 
 # Settings for the messaging service
 #
-# If enabled and configured, LuckPerms will use the messaging system to inform other
-# connected servers of changes. Use the command "/luckperms networksync" to push changes.
+# If enabled and configured, LuckPerms will use the messaging system to inform other connected servers of changes. Use the command "/luckperms networksync" to push changes.
 # Data is NOT stored using this service. It is only used as a messaging platform.
 #
-# If you decide to enable this feature, you should set "sync-minutes" to -1, as there is no need for
-# LuckPerms to poll the database for changes.
+# If you decide to enable this feature, you should set "sync-minutes" to -1, as there is no need for LuckPerms to poll the database for changes.
 #
 # Available options:
 # -> bungee   uses the plugin messaging channels. Must be enabled on all connected servers to work.
-# -> lilypad  uses lilypad pub sub to push changes. You need to have the LilyPad-Connect plugin
-#             installed.
+# -> lilypad  uses lilypad pub sub to push changes. You need to have the LilyPad-Connect plugin installed.
 # -> redis    uses redis pub sub to push changes. Your redis server must be configured below.
 # -> none     nothing
 messaging-service: none
@@ -350,9 +334,7 @@ push-log-entries: true
 
 # If LuckPerms should broadcast received logging entries to players on this platform.
 #
-# If you have LuckPerms installed on your backend servers as well as a BungeeCord proxy, you should
-# set this option to false on either your backends or your proxies, to avoid players being messaged
-# twice about log entries.
+# If you have LuckPerms installed on your backend servers as well as a BungeeCord proxy, you should set this option to false on either your backends or your proxies, to avoid players being messaged twice about log entries.
 broadcast-received-log-entries: true
 
 # Settings for Redis.
@@ -372,25 +354,15 @@ redis:
 # This section allows you to define defaults to give users whenever they connect to the server.
 # The default assignments are highly configurable and conditional.
 #
-# There is one default assignment built into LuckPerms, which will add all users to the "default"
-# group if they are not a member of any other group. This setting cannot be disabled. However, you
-# can use this section to add more of your own.
+# There is one default assignment built into LuckPerms, which will add all users to the "default" group if they are not a member of any other group. This setting cannot be disabled. However, you can use this section to add more of your own.
 #
 # IMPORTANT:
-# In order to save storage space, LuckPerms does not store users who have no permissions defined,
-# and are only a member of the default group. Adding default assignments to this section will negate
-# this effect. It is HIGHLY RECCOMENDED that instead of assigning defaults here, you add permissions
-# to the "default" group, or set the "default" group to inherit other groups, and then use the
-# group-name-rewrite rule above.
+# In order to save storage space, LuckPerms does not store users who have no permissions defined, and are only a member of the default group. Adding default assignments to this section will negate this effect. It is HIGHLY RECCOMENDED that instead of assigning defaults here, you add permissions to the "default" group, or set the "default" group to inherit other groups, and then use the group-name-rewrite rule above.
 #
-# It is also important to note that these rules are considered every time a player logs into the
-# server, and are applied directly to the user's data. Simply removing a rule here will not reverse
-# the effect of that rule on any users who have already had it applied to them.
+# It is also important to note that these rules are considered every time a player logs into the server, and are applied directly to the user's data. Simply removing a rule here will not reverse the effect of that rule on any users who have already had it applied to them.
 #
-# The "has" and "lacks" conditions below support standard boolean logic, using the 'and' & 'or'
-# characters used in Java.
-# e.g. "(some.other.permission | some.permission.other) & some.thing.else" == a user has
-# 'some.other.permission', or 'some.permission.other', and they also have 'some.thing.else'
+# The "has" and "lacks" conditions below support standard boolean logic, using the 'and' & 'or' characters used in Java.
+# e.g. "(some.other.permission | some.permission.other) & some.thing.else" == a user has 'some.other.permission', or 'some.permission.other', and they also have 'some.thing.else'
 #
 # Groups are represented by the permission node: group.<group name>
 # Per server and per world nodes are represented by "server-world/permission" or "server/permission"

--- a/bukkit/src/main/resources/config.yml
+++ b/bukkit/src/main/resources/config.yml
@@ -237,9 +237,9 @@ vault-debug: false
 # Which storage method the plugin should use.
 #
 # See: https://github.com/lucko/LuckPerms/wiki/Choosing-a-Storage-type
-# Currently supported: mysql, mariadb, postgresql, sqlite, h2, json, yaml, hocon, mongodb
+# Currently supported: mysql, mariadb, postgresql, sqlite, h2, json, yaml, hocon, mongodb.
 #
-# Fill out connection info below if you're using MySQL, MariaDB, PostgreSQL or MongoDB
+# Fill out connection info below if you're using MySQL, MariaDB, PostgreSQL or MongoDB.
 # If your MySQL server supports it, the "mariadb" option is preferred over "mysql".
 storage-method: h2
 

--- a/bukkit/src/main/resources/config.yml
+++ b/bukkit/src/main/resources/config.yml
@@ -38,32 +38,23 @@ apply-global-groups: true
 # If users on this server should have global (non-world specific) groups applied
 apply-global-world-groups: true
 
-# If UUIDs should be pulled from the server, or looked up by username based upon previous
-# connections.
+# If UUIDs should be pulled from the server, or looked up by username based upon previous connections.
 #
-# This option should be set to true in most cases. When set to false, in order to get a player's
-# UUID, LuckPerms will:
+# This option should be set to true in most cases. When set to false, in order to get a player's UUID, LuckPerms will:
 #
-# 1. Check if a player with the given username has joined before, if they have, use the UUID they
-#    used on their previous login.
+# 1. Check if a player with the given username has joined before, if they have, use the UUID they used on their previous login.
 # 2. Save and return the players "current" uuid.
 #
 # For offline mode (cracked) servers, a players UUID is generated based upon their username.
 #
 # IMPORTANT:
-# If you are using BungeeCord proxy running in online mode, it is important that "online-mode=false"
-# is set in server.properties, but "bungeecord: true" is set in the spigot.yml. You also need to set
-# "ip_forward: true" in BungeeCord's config.yml.
+# If you are using BungeeCord proxy running in online mode, it is important that "online-mode=false" is set in server.properties, but "bungeecord: true" is set in the spigot.yml. You also need to set "ip_forward: true" in BungeeCord's config.yml.
 #
-# If for whatever reason you are not able to do this, and do not have ip-forward enabled, then you
-# may need to set "use-server-uuids" to false.
+# If for whatever reason you are not able to do this, and do not have ip-forward enabled, then you may need to set "use-server-uuids" to false.
 #
-# If your proxy is running in offline mode, you should still be setting up ip-forwarding as
-# described above, but may also find that you need to set "bungee-online-mode" to false in
-# paper.yml, if you are using Paper. (https://ci.destroystokyo.com/job/PaperSpigot/)
+# If your proxy is running in offline mode, you should still be setting up ip-forwarding as described above, but may also find that you need to set "bungee-online-mode" to false in paper.yml, if you are using Paper. (https://ci.destroystokyo.com/job/PaperSpigot/)
 #
-# This option only really exists for networks who for whatever reason cannot setup proper ip
-# forwarding.
+# This option only really exists for networks who for whatever reason cannot setup proper ip forwarding.
 use-server-uuids: true
 
 # If the servers own UUID cache/lookup facility should be used when there is no record for a player

--- a/bukkit/src/main/resources/config.yml
+++ b/bukkit/src/main/resources/config.yml
@@ -57,18 +57,15 @@ apply-global-world-groups: true
 # This option only really exists for networks who for whatever reason cannot setup proper ip forwarding.
 use-server-uuids: true
 
-# If the servers own UUID cache/lookup facility should be used when there is no record for a player
-# in the LuckPerms cache.
+# If the servers own UUID cache/lookup facility should be used when there is no record for a player in the LuckPerms cache.
 use-server-uuid-cache: false
 
-# If LuckPerms should use the "server-name" property from the "server.properties"
-# file as the "server" option within LuckPerms.
+# If LuckPerms should use the "server-name" property from the "server.properties" file as the "server" option within LuckPerms.
 use-server-properties-name: false
 
 # If set to true, LuckPerms will allow usernames with non alphanumeric characters.
 #
-# Note that due to the design of the storage implementation, usernames must still be
-# 16 characters or less.
+# Note that due to the design of the storage implementation, usernames must still be 16 characters or less.
 allow-invalid-usernames: false
 
 # If LuckPerms should produce extra logging output when it handles logins.
@@ -78,8 +75,7 @@ debug-logins: false
 # If the plugin should send log notifications to users whenever permissions are modified.
 log-notify: true
 
-# Mirrors world names. Whenever LuckPerms checks what world a user is in, if the world name is in
-# this list, the value assigned will be sent forward for permission calculation instead.
+# Mirrors world names. Whenever LuckPerms checks what world a user is in, if the world name is in this list, the value assigned will be sent forward for permission calculation instead.
 world-rewrite:
 #  world_nether: world
 #  world_the_end: world
@@ -101,17 +97,14 @@ temporary-add-behaviour: deny
 #                           directly and indirectly
 primary-group-calculation: parents-by-weight
 
-# If set to false, the plugin will allow a Users primary group to be removed with the
-# 'parent remove' command, and will set their primary group back to default.
+# If set to false, the plugin will allow a Users primary group to be removed with the 'parent remove' command, and will set their primary group back to default.
 prevent-primary-group-removal: false
 
 # If the plugin should check for "extra" permissions with users run LP commands.
 #
-# These extra permissions allow finer control over what users can do with each command, and
-# who they have access to edit.
+# These extra permissions allow finer control over what users can do with each command, and who they have access to edit.
 #
-# The permissions are *not* static, unlike the 'base' permisssions, and will depend upon the
-# arguments given within the command.
+# The permissions are *not* static, unlike the 'base' permisssions, and will depend upon the arguments given within the command.
 argument-based-command-permissions: false
 
 
@@ -122,13 +115,11 @@ argument-based-command-permissions: false
 # +----------------------------------------------------------------------------------------------+ #
 
 # If the plugin should apply wildcard permissions.
-# If set to true, LuckPerms will detect wildcard permissions, and resolve & apply all registered
-# permissions matching the wildcard.
+# If set to true, LuckPerms will detect wildcard permissions, and resolve & apply all registered permissions matching the wildcard.
 apply-wildcards: true
 
 # If the plugin should parse regex permissions.
-# If set to true, LuckPerms will detect regex permissions, marked with "r=" at the start of the
-# node, and resolve & apply all registered permissions matching the regex.
+# If set to true, LuckPerms will detect regex permissions, marked with "r=" at the start of the node, and resolve & apply all registered permissions matching the regex.
 apply-regex: true
 
 # If the plugin should complete and apply shorthand permissions.
@@ -136,21 +127,16 @@ apply-regex: true
 apply-shorthand: true
 
 # If the plugin should apply Bukkit child permissions.
-# Plugin authors can define custom permissions structures for their plugin, which will be resolved
-# and used by LuckPerms if this setting is enabled.
+# Plugin authors can define custom permissions structures for their plugin, which will be resolved and used by LuckPerms if this setting is enabled.
 apply-bukkit-child-permissions: true
 
 # If the plugin should apply Bukkit default permissions.
-# Plugin authors can define permissions which should be given to all users by default, or setup
-# permissions which should/shouldn't be given to opped players.
+# Plugin authors can define permissions which should be given to all users by default, or setup permissions which should/shouldn't be given to opped players.
 # If this option is set to false, LuckPerms will ignore these defaults.
 apply-bukkit-default-permissions: true
 
 # If the plugin should apply attachment permissions.
-# Other plugins on the server are able to add their own "permission attachments" to players. This
-# allows them to grant players additional permissions which last until the end of the session, or
-# until they're removed. If this option is set to false, LuckPerms will not include these attachment
-# permissions when considering if a player should have access to a certain permission.
+# Other plugins on the server are able to add their own "permission attachments" to players. This allows them to grant players additional permissions which last until the end of the session, or until they're removed. If this option is set to false, LuckPerms will not include these attachment permissions when considering if a player should have access to a certain permission.
 apply-bukkit-attachment-permissions: true
 
 # Define special group weights for this server.
@@ -201,26 +187,19 @@ meta-formatting:
 # |                                 OP (Server Operator) Settings                                | #
 # +----------------------------------------------------------------------------------------------+ #
 
-# If the vanilla OP system is enabled. If set to false, all users will be de-opped, and the op/deop
-# commands will be disabled.
+# If the vanilla OP system is enabled. If set to false, all users will be de-opped, and the op/deop commands will be disabled.
 enable-ops: true
 
-# If set to true, any user with the permission "luckperms.autoop" will automatically be granted
-# server operator status. This permission can be inherited, or set on specific servers/worlds,
-# temporarily, etc.
+# If set to true, any user with the permission "luckperms.autoop" will automatically be granted server operator status. This permission can be inherited, or set on specific servers/worlds, temporarily, etc.
 #
-# Additionally, setting this to true will force the "enable-ops" option above to false. All users
-# will be de-opped unless they have the permission node, and the op/deop commands will be disabled.
+# Additionally, setting this to true will force the "enable-ops" option above to false. All users will be de-opped unless they have the permission node, and the op/deop commands will be disabled.
 #
-# It is important to note that this setting is only checked when a player first joins the server,
-# and when they switch worlds. Therefore, simply removing this permission from a user will not
-# automatically de-op them. A player needs to relog to have the change take effect.
+# It is important to note that this setting is only checked when a player first joins the server, and when they switch worlds. Therefore, simply removing this permission from a user will not automatically de-op them. A player needs to relog to have the change take effect.
 #
 # It is recommended that you use this option instead of assigning a single '*' permission.
 auto-op: false
 
-# If opped players should be allowed to use LuckPerms commands. Set to false to only allow users who
-# have the permissions access to the commands
+# If opped players should be allowed to use LuckPerms commands. Set to false to only allow users who have the permissions access to the commands
 commands-allow-op: true
 
 
@@ -234,8 +213,7 @@ commands-allow-op: true
 # When this option is set to false, the server value defined above under "server" is used.
 use-vault-server: false
 
-# The name of the server used within Vault operations. If you don't want Vault operations to be
-# server specific, set this to "global".
+# The name of the server used within Vault operations. If you don't want Vault operations to be server specific, set this to "global".
 #
 # Will only take effect if use-vault-server is set to true above.
 vault-server: global

--- a/bukkit/src/main/resources/config.yml
+++ b/bukkit/src/main/resources/config.yml
@@ -372,25 +372,17 @@ redis:
 # Explanation of the examples below: (they're just to demonstrate the features & use cases)
 #
 # rule1:
-# If a user is either in the vip or vip+ group, and they have the "titles.titlecollector" permission
-# set to true, and the "some.random.permission" set to false... if they're not in the group
-# "prison_titlepack" on the "prison" server, then give add them to the "prison_titlepack" group on
-# the "prison" server, and remove "some.random.permission".
+# If a user is either in the vip or vip+ group, and they have the "titles.titlecollector" permission set to true, and the "some.random.permission" set to false... if they're not in the group "prison_titlepack" on the "prison" server, then give add them to the "prison_titlepack" group on the "prison" server, and remove "some.random.permission".
 #
 # rule2:
-# If the user isn't in any of the following groups on the skyblock server: sb_level1, sb_level2,
-# sb_level3, then add them to sb_level1 on the skyblock server.
+# If the user isn't in any of the following groups on the skyblock server: sb_level1, sb_level2, sb_level3, then add them to sb_level1 on the skyblock server.
 #
 # rule3:
-# If the user is a member of the default group, remove them from default, add them to member, and
-# set their primary group to member.
+# If the user is a member of the default group, remove them from default, add them to member, and set their primary group to member.
 #
-# WARNING: Unlike internal commands, this system does not ensure that a group exists before adding
-# a user to it. It also does not unsure that a user is a member of a group before making that group
-# their primary group.
+# WARNING: Unlike internal commands, this system does not ensure that a group exists before adding a user to it. It also does not unsure that a user is a member of a group before making that group their primary group.
 #
-# Before you use "give: group.<name>" or "set-primary-group", make sure that the group exists, and
-# that the user is a member of the group.
+# Before you use "give: group.<name>" or "set-primary-group", make sure that the group exists, and that the user is a member of the group.
 default-assignments:
 #  rule1:
 #    if:


### PR DESCRIPTION
I've noticed a lot of line breaks in the middle of sentences within the comments. I've gone ahead and removed all the ones that don't make sense, but kept line breaks that are there for formatting reasons.