### PR TITLE
Added explicit column names in INSERT queries.

### DIFF
--- a/common/src/main/java/me/lucko/luckperms/common/storage/dao/sql/SqlDao.java
+++ b/common/src/main/java/me/lucko/luckperms/common/storage/dao/sql/SqlDao.java
@@ -85,7 +85,7 @@ public class SqlDao extends AbstractDao {
     private static final String PLAYER_SELECT_UUID_BY_USERNAME = "SELECT uuid FROM {prefix}players WHERE username=? LIMIT 1";
     private static final String PLAYER_SELECT_USERNAME_BY_UUID = "SELECT username FROM {prefix}players WHERE uuid=? LIMIT 1";
     private static final String PLAYER_UPDATE_USERNAME_FOR_UUID = "UPDATE {prefix}players SET username=? WHERE uuid=?";
-    private static final String PLAYER_INSERT = "INSERT INTO {prefix}players VALUES(?, ?, ?)";
+    private static final String PLAYER_INSERT = "INSERT INTO {prefix}players (uuid, username, primary_group) VALUES(?, ?, ?)";
     private static final String PLAYER_SELECT_ALL_UUIDS_BY_USERNAME = "SELECT uuid FROM {prefix}players WHERE username=? AND NOT uuid=?";
     private static final String PLAYER_DELETE_ALL_UUIDS_BY_USERNAME = "DELETE FROM {prefix}players WHERE username=? AND NOT uuid=?";
     private static final String PLAYER_SELECT_BY_UUID = "SELECT username, primary_group FROM {prefix}players WHERE uuid=?";
@@ -105,7 +105,7 @@ public class SqlDao extends AbstractDao {
     private static final String POSTGRESQL_GROUP_INSERT = "INSERT INTO {prefix}groups (name) VALUES(?) ON CONFLICT (name) DO NOTHING";
     private static final String GROUP_DELETE = "DELETE FROM {prefix}groups WHERE name=?";
 
-    private static final String TRACK_INSERT = "INSERT INTO {prefix}tracks VALUES(?, ?)";
+    private static final String TRACK_INSERT = "INSERT INTO {prefix}tracks (name, groups) VALUES(?, ?)";
     private static final String TRACK_SELECT = "SELECT groups FROM {prefix}tracks WHERE name=?";
     private static final String TRACK_SELECT_ALL = "SELECT * FROM {prefix}tracks";
     private static final String TRACK_UPDATE = "UPDATE {prefix}tracks SET groups=? WHERE name=?";


### PR DESCRIPTION
The absence of an explicit indication of the column names leads to some problems. In particular, this happens when using ORM, in which it is inconvenient to specify the order of the columns.