### PR TITLE
Use neutral color to display potentially colored names (Fixes #1170)

### DIFF
--- a/common/src/main/java/me/lucko/luckperms/common/model/Group.java
+++ b/common/src/main/java/me/lucko/luckperms/common/model/Group.java
@@ -94,7 +94,7 @@ public class Group extends PermissionHolder implements Identifiable<String> {
     @Override
     public String getFriendlyName() {
         Optional<String> dn = getDisplayName();
-        return dn.map(s -> this.name + " (" + s + ")").orElse(this.name);
+        return dn.map(s -> this.name + " &r(" + s + "&r)").orElse(this.name);
     }
 
     public Optional<String> getDisplayName() {


### PR DESCRIPTION
This fixes issues with the colors leaking from a group name into messages after the name if it's colored and doesn't end with a reset. Coloring both, the first and the last parentheses makes it look nicer and easier to see if the display name was colored or not (white is mostly associated with not colored at all)