### PR TITLE
Fix Typo with /export 

### DIFF
--- a/common/src/main/java/me/lucko/luckperms/common/locale/command/CommandSpec.java
+++ b/common/src/main/java/me/lucko/luckperms/common/locale/command/CommandSpec.java
@@ -92,7 +92,7 @@ public enum CommandSpec {
                     Argument.create("file", true, "the file to import from")
             )
     ),
-    EXPORT("Exports all permissions data to an 'export' file. Be re-imported at a later time.", "/%s export <file>",
+    EXPORT("Exports all permissions data to an 'export' file. To be re-imported at a later time.", "/%s export <file>",
             Argument.list(
                     Argument.create("file", true, "the file to export to")
             )

--- a/common/src/main/java/me/lucko/luckperms/common/locale/command/CommandSpec.java
+++ b/common/src/main/java/me/lucko/luckperms/common/locale/command/CommandSpec.java
@@ -92,7 +92,7 @@ public enum CommandSpec {
                     Argument.create("file", true, "the file to import from")
             )
     ),
-    EXPORT("Exports all permissions data to an 'export' file. Be be re-imported at a later time.", "/%s export <file>",
+    EXPORT("Exports all permissions data to an 'export' file. Be re-imported at a later time.", "/%s export <file>",
             Argument.list(
                     Argument.create("file", true, "the file to export to")
             )

--- a/common/src/main/java/me/lucko/luckperms/common/locale/command/CommandSpec.java
+++ b/common/src/main/java/me/lucko/luckperms/common/locale/command/CommandSpec.java
@@ -92,7 +92,7 @@ public enum CommandSpec {
                     Argument.create("file", true, "the file to import from")
             )
     ),
-    EXPORT("Exports all permissions data to an 'export' file. To be re-imported at a later time.", "/%s export <file>",
+    EXPORT("Exports all permissions data to an 'export' file. Can be re-imported at a later time.", "/%s export <file>",
             Argument.list(
                     Argument.create("file", true, "the file to export to")
             )


### PR DESCRIPTION
Fixed up a typo on line 95 

"Exports all permissions data to an 'export' file. Be be re-imported at a later time."
TO
"Exports all permissions data to an 'export' file. Can be re-imported at a later time."