### PR TITLE
Update config description of messaging service

### DIFF
--- a/bukkit/src/main/resources/config.yml
+++ b/bukkit/src/main/resources/config.yml
@@ -214,6 +214,10 @@ watch-files: true
 #   => redis     Uses Redis pub-sub to push changes. Your server connection info must be configured
 #                below.
 #   => none      Disables the service.
+#                Exception is when you're using a SQL storage. In this case will this option default
+#                to 'sql'. Use 'notsql' to disable this completely.
+#   => notsql    Disable the default 'sql' messaging-service. This is only useful if you're using
+#                a SQL storage and don't want to have a messaging-service set.
 messaging-service: none
 
 # If LuckPerms should automatically push updates after a change has been made with a command.

--- a/bungee/src/main/resources/config.yml
+++ b/bungee/src/main/resources/config.yml
@@ -212,6 +212,10 @@ watch-files: true
 #   => redisbungee   Uses Redis pub-sub to push changes, using the RedisBungee API. You need to have
 #                    the RedisBungee plugin installed.
 #   => none          Disables the service.
+#                    Exception is when you're using a SQL storage. In this case will this option default
+#                    to 'sql'. Use 'notsql' to disable this completely.
+#   => notsql        Disable the default 'sql' messaging-service. This is only useful if you're using
+#                    a SQL storage and don't want to have a messaging-service set.
 messaging-service: none
 
 # If LuckPerms should automatically push updates after a change has been made with a command.

--- a/nukkit/src/main/resources/config.yml
+++ b/nukkit/src/main/resources/config.yml
@@ -209,6 +209,10 @@ watch-files: true
 #   => redis     Uses Redis pub-sub to push changes. Your server connection info must be configured
 #                below.
 #   => none      Disables the service.
+#                Exception is when you're using a SQL storage. In this case will this option default
+#                to 'sql'. Use 'notsql' to disable this completely.
+#   => notsql    Disable the default 'sql' messaging-service. This is only useful if you're using
+#                a SQL storage and don't want to have a messaging-service set.
 messaging-service: none
 
 # If LuckPerms should automatically push updates after a change has been made with a command.

--- a/sponge/src/main/resources/luckperms.conf
+++ b/sponge/src/main/resources/luckperms.conf
@@ -217,6 +217,10 @@ watch-files = true
 #   => redis     Uses Redis pub-sub to push changes. Your server connection info must be configured
 #                below.
 #   => none      Disables the service.
+#                Exception is when you're using a SQL storage. In this case will this option default
+#                to 'sql'. Use 'notsql' to disable this completely.
+#   => notsql    Disable the default 'sql' messaging-service. This is only useful if you're using
+#                a SQL storage and don't want to have a messaging-service set.
 messaging-service = "none"
 
 # If LuckPerms should automatically push updates after a change has been made with a command.

--- a/velocity/src/main/resources/config.yml
+++ b/velocity/src/main/resources/config.yml
@@ -203,6 +203,10 @@ watch-files: true
 #   => redis         Uses Redis pub-sub to push changes. Your server connection info must be
 #                    configured below.
 #   => none          Disables the service.
+#                    Exception is when you're using a SQL storage. In this case will this option default
+#                    to 'sql'. Use 'notsql' to disable this completely.
+#   => notsql        Disable the default 'sql' messaging-service. This is only useful if you're using
+#                    a SQL storage and don't want to have a messaging-service set.
 messaging-service: none
 
 # If LuckPerms should automatically push updates after a change has been made with a command.


### PR DESCRIPTION
The LuckPerms configs contain a description of the messaging services you can use.
Those are partially confusing and maybe even misleading.

For example does the description of `none` state that it...
> Disables the service.

...while `sql` says the following information:
> Uses the SQL database to form a queue system for communication. Will only work when 'storage-method' is set to MySQL or MariaDB. **This is chosen by default if the option is set to 'none' and SQL storage is in use. Set to 'notsql' to disable this.**

This PR adds a bit more description about how `none` works in certain situations and also lists and explains the `notsql` option since according to the description of sql is this a valid and available option which shouldn't be kept secret.