### PR TITLE
Fixed StringIndexOutOfBoundsException when calling the event

### DIFF
--- a/bukkit/src/main/java/me/lucko/luckperms/bukkit/BukkitAsyncCommandExecutor.java
+++ b/bukkit/src/main/java/me/lucko/luckperms/bukkit/BukkitAsyncCommandExecutor.java
@@ -54,7 +54,7 @@ public class BukkitAsyncCommandExecutor extends BukkitCommandExecutor implements
         }
 
         String buffer = e.getBuffer();
-        if (buffer.charAt(0) == '/') {
+        if (buffer.startsWith("/")) {
             buffer = buffer.substring(1);
         }
 


### PR DESCRIPTION
Well, this patch contains a change that the minecraft commands need to make the validation correct and successful. If you want to know why I made this change (error source below) because minecraft and all other commands, we always started with "/" character, whatever the command, consuming less memory since the "char" variable type memory leaks.

How to reproduce this error?
Well, this bug just happened once when I leave the server without executing commands and other chat stuff. It wasn't for anyone, but it gives me that.

Full error:
```
[16:46:59 ERROR]: Could not pass event AsyncTabCompleteEvent to LuckPerms v5.0.63
java.lang.StringIndexOutOfBoundsException: null
        at java.lang.String.charAt(String.java:1374) ~[?:1.8.0_242]
        at me.lucko.luckperms.bukkit.BukkitAsyncCommandExecutor.onAsyncTabComplete(BukkitAsyncCommandExecutor.java:57) ~[?:?]
        at com.destroystokyo.paper.event.executor.asm.generated.GeneratedEventExecutor11.execute(Unknown Source) ~[?:?]
        at org.bukkit.plugin.EventExecutor.lambda$create$1(EventExecutor.java:69) ~[patched_1.15.2.jar:git-Paper-65]
        at org.bukkit.plugin.EventExecutor$$Lambda$2310/0000000000000000.execute(Unknown Source) ~[?:?]
        at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:76) ~[patched_1.15.2.jar:git-Paper-65]
        at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:70) ~[patched_1.15.2.jar:git-Paper-65]
        at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:545) ~[patched_1.15.2.jar:git-Paper-65]
        at org.bukkit.event.Event.callEvent(Event.java:45) ~[patched_1.15.2.jar:git-Paper-65]
        at org.bukkit.craftbukkit.v1_15_R1.command.ConsoleCommandCompleter.complete(ConsoleCommandCompleter.java:36) ~[patched_1.15.2.jar:git-Paper-65]
        at org.jline.reader.impl.LineReaderImpl.doComplete(LineReaderImpl.java:4147) ~[patched_1.15.2.jar:git-Paper-65]
        at org.jline.reader.impl.LineReaderImpl.completeWord(LineReaderImpl.java:4076) ~[patched_1.15.2.jar:git-Paper-65]
        at org.jline.reader.impl.LineReaderImpl$$Lambda$1959/0000000000000000.apply(Unknown Source) ~[?:?]
        at org.jline.reader.impl.LineReaderImpl$1.apply(LineReaderImpl.java:3630) ~[patched_1.15.2.jar:git-Paper-65]
        at org.jline.reader.impl.LineReaderImpl.readLine(LineReaderImpl.java:603) ~[patched_1.15.2.jar:git-Paper-65]
        at org.jline.reader.impl.LineReaderImpl.readLine(LineReaderImpl.java:418) ~[patched_1.15.2.jar:git-Paper-65]
        at net.minecrell.terminalconsole.SimpleTerminalConsole.readCommands(SimpleTerminalConsole.java:158) ~[patched_1.15.2.jar:git-Paper-65]
        at net.minecrell.terminalconsole.SimpleTerminalConsole.start(SimpleTerminalConsole.java:141) ~[patched_1.15.2.jar:git-Paper-65]
        at net.minecraft.server.v1_15_R1.DedicatedServer$2.run(DedicatedServer.java:90) ~[patched_1.15.2.jar:git-Paper-65]
```