### PR TITLE
Resolve server crash from concurrent permissions request

### DIFF
--- a/common/src/main/java/me/lucko/luckperms/common/cacheddata/type/PermissionCache.java
+++ b/common/src/main/java/me/lucko/luckperms/common/cacheddata/type/PermissionCache.java
@@ -71,7 +71,7 @@ public class PermissionCache implements CachedPermissionData {
     public PermissionCache(QueryOptions queryOptions, CacheMetadata metadata, CalculatorFactory calculatorFactory) {
         this.queryOptions = queryOptions;
         this.permissions = new ConcurrentHashMap<>();
-        this.permissionsUnmodifiable = Collections.unmodifiableMap(this.permissions);
+        this.permissionsUnmodifiable = Collections.unmodifiableMap(new ConcurrentHashMap<>(this.permissions));
 
         this.calculator = calculatorFactory.build(queryOptions, metadata);
         this.calculator.setSourcePermissions(this.permissions); // Initial setup.


### PR DESCRIPTION
User of the Quests plugin reported issue https://github.com/PikaMug/Quests/issues/1121 with thread dump https://hastebin.com/dujucemeno.shell

Attempting to iterate players' effective permissions concurrently results in a server crash. To wit:

https://github.com/lucko/LuckPerms/blob/b84518e1f1a95cc49b790b5ba9a9a5242f661489/bukkit/src/main/java/me/lucko/luckperms/bukkit/inject/permissible/LuckPermsPermissible.java#L213-L217

While the unmodifiable `getPermissionMap()` offers protection, it is my understanding that the map implementations (namely HashMap.entrySet) are non-volatile fields and are lazily initialized such that access to these fields is unsafe from all other threads. See https://stackoverflow.com/a/29058755

https://github.com/lucko/LuckPerms/blob/01e17adf82d00b81b4b5e86f0ce115d64811bcdc/common/src/main/java/me/lucko/luckperms/common/cacheddata/type/PermissionCache.java#L74

Therefore, I believe the issue can be addressed by returning a new instance of `this.permissions`. I've forgone using a basic HashMap as the class already imports ConcurrentHashMap. Thanks for your time!

