### PR TITLE
Support SporkBukkit's modifications to the permissions API

### DIFF
--- a/bukkit/src/main/java/me/lucko/luckperms/bukkit/inject/permissible/LuckPermsPermissible.java
+++ b/bukkit/src/main/java/me/lucko/luckperms/bukkit/inject/permissible/LuckPermsPermissible.java
@@ -56,6 +56,7 @@ import java.util.ListIterator;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.Spliterator;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -351,10 +352,12 @@ public class LuckPermsPermissible extends PermissibleBase {
      *
      * Some (clever/dumb??) plugins attempt to add/remove/query attachments using reflection.
      *
+     * Some bukkit forks change the attachments list to be a set, so support both interfaces.
+     *
      * An instance of this map is injected into the super instance so these plugins continue
      * to work with LuckPerms.
      */
-    private final class FakeAttachmentList implements List<PermissionAttachment> {
+    private final class FakeAttachmentList implements List<PermissionAttachment>, Set<PermissionAttachment> {
 
         @Override
         public boolean add(PermissionAttachment attachment) {
@@ -397,6 +400,11 @@ public class LuckPermsPermissible extends PermissibleBase {
         @Override
         public Iterator<PermissionAttachment> iterator() {
             return ImmutableList.<PermissionAttachment>copyOf(LuckPermsPermissible.this.hookedAttachments).iterator();
+        }
+
+        @Override
+        public Spliterator<PermissionAttachment> spliterator() {
+            return ImmutableList.<PermissionAttachment>copyOf(LuckPermsPermissible.this.hookedAttachments).spliterator();
         }
 
         @Override

--- a/bukkit/src/main/java/me/lucko/luckperms/bukkit/inject/permissible/PermissibleInjector.java
+++ b/bukkit/src/main/java/me/lucko/luckperms/bukkit/inject/permissible/PermissibleInjector.java
@@ -33,7 +33,7 @@ import org.bukkit.permissions.PermissibleBase;
 import org.bukkit.permissions.PermissionAttachment;
 
 import java.lang.reflect.Field;
-import java.util.List;
+import java.util.Collection;
 
 /**
  * Injects a {@link LuckPermsPermissible} into a {@link Player}.
@@ -100,7 +100,7 @@ public final class PermissibleInjector {
         // Move attachments over from the old permissible
 
         //noinspection unchecked
-        List<PermissionAttachment> attachments = (List<PermissionAttachment>) PERMISSIBLE_BASE_ATTACHMENTS_FIELD.get(oldPermissible);
+        Collection<PermissionAttachment> attachments = (Collection<PermissionAttachment>) PERMISSIBLE_BASE_ATTACHMENTS_FIELD.get(oldPermissible);
 
         newPermissible.convertAndAddAttachments(attachments);
         attachments.clear();


### PR DESCRIPTION
There are some performance forks of Bukkit, such as [SportPaper](github.com/Electroid/SportPaper), that rely on patch that modifies the `PermissibleBase`.

```patch
 public class PermissibleBase implements Permissible {
     private ServerOperator opable = null;
     private Permissible parent = this;
-    private final List<PermissionAttachment> attachments = new LinkedList<PermissionAttachment>();
-    private final Map<String, PermissionAttachmentInfo> permissions = new HashMap<String, PermissionAttachmentInfo>();
+    private final Set<PermissionAttachment> attachments = new LinkedHashSet<PermissionAttachment>();
+    private final ListMultimap<String, PermissionAttachmentInfo> permissions = ArrayListMultimap.create();
```

This small change breaks an underlying assumption in `PermissibleInjector` and `LuckPermsPermisslble`: that the `attachments` field is a `List`. Thus, all logins are rejected with the following error:

```log
[LuckPerms] Exception thrown when setting up permissions for <uuid> - <username> - denying login.
[WARN]: java.lang.ClassCastException: java.util.LinkedHashSet cannot be cast to java.util.List
[WARN]:        at me.lucko.luckperms.bukkit.inject.permissible.PermissibleInjector.inject(PermissibleInjector.java:103)
[WARN]:        at me.lucko.luckperms.bukkit.listeners.BukkitConnectionListener.onPlayerLogin(BukkitConnectionListener.java:193)
```

I've proposed a very simple fix that mitigates this issue so more servers can use your plugin. Thanks and happy to answer any questions if you have them. Cheers!