### PR TITLE
Fix the link to Storage types comparison

### DIFF
--- a/bukkit/src/main/resources/config.yml
+++ b/bukkit/src/main/resources/config.yml
@@ -57,7 +57,7 @@ use-server-uuid-cache: false
 # How the plugin should store data
 #
 # - The various options are explained in more detail on the wiki:
-#   https://github.com/lucko/LuckPerms/wiki/Choosing-a-Storage-type
+#   https://github.com/lucko/LuckPerms/wiki/Storage-types
 #
 # - Possible options:
 #

--- a/bungee/src/main/resources/config.yml
+++ b/bungee/src/main/resources/config.yml
@@ -54,7 +54,7 @@ use-server-uuid-cache: false
 # How the plugin should store data
 #
 # - The various options are explained in more detail on the wiki:
-#   https://github.com/lucko/LuckPerms/wiki/Choosing-a-Storage-type
+#   https://github.com/lucko/LuckPerms/wiki/Storage-types
 #
 # - Possible options:
 #

--- a/nukkit/src/main/resources/config.yml
+++ b/nukkit/src/main/resources/config.yml
@@ -57,7 +57,7 @@ use-server-uuid-cache: false
 # How the plugin should store data
 #
 # - The various options are explained in more detail on the wiki:
-#   https://github.com/lucko/LuckPerms/wiki/Choosing-a-Storage-type
+#   https://github.com/lucko/LuckPerms/wiki/Storage-types
 #
 # - Possible options:
 #

--- a/sponge/src/main/resources/luckperms.conf
+++ b/sponge/src/main/resources/luckperms.conf
@@ -57,7 +57,7 @@ use-server-uuid-cache = false
 # How the plugin should store data
 #
 # - The various options are explained in more detail on the wiki:
-#   https://github.com/lucko/LuckPerms/wiki/Choosing-a-Storage-type
+#   https://github.com/lucko/LuckPerms/wiki/Storage-types
 #
 # - Possible options:
 #

--- a/velocity/src/main/resources/config.yml
+++ b/velocity/src/main/resources/config.yml
@@ -47,7 +47,7 @@ server: proxy
 # How the plugin should store data
 #
 # - The various options are explained in more detail on the wiki:
-#   https://github.com/lucko/LuckPerms/wiki/Choosing-a-Storage-type
+#   https://github.com/lucko/LuckPerms/wiki/Storage-types
 #
 # - Possible options:
 #


### PR DESCRIPTION
The link to [Storage types](https://github.com/lucko/LuckPerms/wiki/Storage-types) seemed to be outdated