### PR TITLE
Improve "properties" section of config files

### DIFF
--- a/bukkit/src/main/resources/config.yml
+++ b/bukkit/src/main/resources/config.yml
@@ -139,12 +139,13 @@ data:
     #   useUnicode: true
     #   characterEncoding: utf8
     #
-    # You can also use this section to disable SSL connections, by setting:
-    #   useSSL: false
-    #   verifyServerCertificate: false
+    # If you encounter SSL errors in the console ("Establishing SSL connection without ...") will
+    # you need to uncomment "useSSL: false" and "verifyServerCertificate: false" below to fix this.
     properties:
       useUnicode: true
       characterEncoding: utf8
+      #useSSL: false
+      #verifyServerCertificate: false
 
   # The prefix for all LuckPerms SQL tables.
   # - Change this is you want to use different tables for different servers.

--- a/bungee/src/main/resources/config.yml
+++ b/bungee/src/main/resources/config.yml
@@ -135,13 +135,14 @@ data:
     # these if you are using PostgreSQL)
     #   useUnicode: true
     #   characterEncoding: utf8
-    #
-    # You can also use this section to disable SSL connections, by setting:
-    #   useSSL: false
-    #   verifyServerCertificate: false
-    properties:
-      useUnicode: true
-      characterEncoding: utf8
+      #
+      # If you encounter SSL errors in the console ("Establishing SSL connection without ...") will
+      # you need to uncomment "useSSL: false" and "verifyServerCertificate: false" below to fix this.
+      properties:
+        useUnicode: true
+        characterEncoding: utf8
+        #useSSL: false
+        #verifyServerCertificate: false
 
   # The prefix for all LuckPerms SQL tables.
   # - Change this is you want to use different tables for different servers.

--- a/bungee/src/main/resources/config.yml
+++ b/bungee/src/main/resources/config.yml
@@ -135,14 +135,14 @@ data:
     # these if you are using PostgreSQL)
     #   useUnicode: true
     #   characterEncoding: utf8
-      #
-      # If you encounter SSL errors in the console ("Establishing SSL connection without ...") will
-      # you need to uncomment "useSSL: false" and "verifyServerCertificate: false" below to fix this.
-      properties:
-        useUnicode: true
-        characterEncoding: utf8
-        #useSSL: false
-        #verifyServerCertificate: false
+    #
+    # If you encounter SSL errors in the console ("Establishing SSL connection without ...") will
+    # you need to uncomment "useSSL: false" and "verifyServerCertificate: false" below to fix this.
+    properties:
+      useUnicode: true
+      characterEncoding: utf8
+      #useSSL: false
+      #verifyServerCertificate: false
 
   # The prefix for all LuckPerms SQL tables.
   # - Change this is you want to use different tables for different servers.

--- a/nukkit/src/main/resources/config.yml
+++ b/nukkit/src/main/resources/config.yml
@@ -139,12 +139,13 @@ data:
     #   useUnicode: true
     #   characterEncoding: utf8
     #
-    # You can also use this section to disable SSL connections, by setting:
-    #   useSSL: false
-    #   verifyServerCertificate: false
+    # If you encounter SSL errors in the console ("Establishing SSL connection without ...") will
+    # you need to uncomment "useSSL: false" and "verifyServerCertificate: false" below to fix this.
     properties:
       useUnicode: true
       characterEncoding: utf8
+      #useSSL: false
+      #verifyServerCertificate: false
 
   # The prefix for all LuckPerms SQL tables.
   # - Change this is you want to use different tables for different servers.

--- a/sponge/src/main/resources/luckperms.conf
+++ b/sponge/src/main/resources/luckperms.conf
@@ -139,12 +139,13 @@ data {
     #   useUnicode = true
     #   characterEncoding = "utf8"
     #
-    # You can also use this section to disable SSL connections, by setting:
-    #   useSSL = false
-    #   verifyServerCertificate = false
+    # If you encounter SSL errors in the console ("Establishing SSL connection without ...") will
+    # you need to uncomment "useSSL = false" and "verifyServerCertificate = false" below to fix this.
     properties {
       useUnicode = true
       characterEncoding = "utf8"
+      #useSSL = false
+      #verifyServerCertificate = false
     }
   }
 

--- a/velocity/src/main/resources/config.yml
+++ b/velocity/src/main/resources/config.yml
@@ -129,12 +129,13 @@ data:
     #   useUnicode: true
     #   characterEncoding: utf8
     #
-    # You can also use this section to disable SSL connections, by setting:
-    #   useSSL: false
-    #   verifyServerCertificate: false
+    # If you encounter SSL errors in the console ("Establishing SSL connection without ...") will
+    # you need to uncomment "useSSL: false" and "verifyServerCertificate: false" below to fix this.
     properties:
       useUnicode: true
       characterEncoding: utf8
+      #useSSL: false
+      #verifyServerCertificate: false
 
   # The prefix for all LuckPerms SQL tables.
   # - Change this is you want to use different tables for different servers.


### PR DESCRIPTION
This PR improves the properties section (`data.pool-settings.properties`) by moving the mentioned `useSSL: false` and `verifyServerCertificate: false` parts below the `characterEncoding: utf8` part, acting as uncommented options.

The goal of this is to prevent confusion, as some people will assume, that you just need to uncomment the mentioned options and not add them below the properties one (see #2203 for a recent case)