### PR TITLE
Change ContextSet 'satisfy' behaviour

### DIFF
--- a/api/src/main/java/net/luckperms/api/context/ContextSet.java
+++ b/api/src/main/java/net/luckperms/api/context/ContextSet.java
@@ -197,12 +197,28 @@ public interface ContextSet extends Iterable<Context> {
     }
 
     /**
+     * Returns if the {@link ContextSet} contains any of the given context pairings.
+     *
+     * @param key the key to look for
+     * @param values the values to look for
+     * @return true if the set contains any of the pairs
+     * @since 5.1
+     */
+    default boolean containsAny(@NonNull String key, @NonNull Iterable<String> values) {
+        for (String value : values) {
+            if (contains(key, value)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * Returns if this {@link ContextSet} is fully "satisfied" by another set.
      *
      * <p>For a context set to "satisfy" another, it must itself contain all of
-     * the context pairings in the other set.</p>
-     *
-     * <p>Mathematically, this method returns true if this set is a <b>subset</b> of the other.</p>
+     * the context keys with values in the other set, with at least one of the values
+     * matching.</p>
      *
      * @param other the other set to check
      * @return true if all entries in this set are also in the other set

--- a/common/src/main/java/me/lucko/luckperms/common/context/contextset/ImmutableContextSetImpl.java
+++ b/common/src/main/java/me/lucko/luckperms/common/context/contextset/ImmutableContextSetImpl.java
@@ -40,6 +40,7 @@ import net.luckperms.api.context.MutableContextSet;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
 
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Objects;
@@ -145,14 +146,11 @@ public final class ImmutableContextSetImpl extends AbstractContextSet implements
         } else if (other.isEmpty()) {
             // this set isn't empty, but the other one is
             return false;
-        } else if (this.size() > other.size()) {
-            // this set has more unique entries than the other set, so there's no way this can be satisfied.
-            return false;
         } else {
             // neither are empty, we need to compare the individual entries
-            Set<Map.Entry<String, String>> entries = this.map.entries();
-            for (Map.Entry<String, String> e : entries) {
-                if (!other.contains(e.getKey(), e.getValue())) {
+            Set<Map.Entry<String, Collection<String>>> entries = this.map.asMap().entrySet();
+            for (Map.Entry<String, Collection<String>> e : entries) {
+                if (!other.containsAny(e.getKey(), e.getValue())) {
                     return false;
                 }
             }

--- a/common/src/main/java/me/lucko/luckperms/common/context/contextset/MutableContextSetImpl.java
+++ b/common/src/main/java/me/lucko/luckperms/common/context/contextset/MutableContextSetImpl.java
@@ -198,15 +198,12 @@ public final class MutableContextSetImpl extends AbstractContextSet implements M
         } else if (other.isEmpty()) {
             // this set isn't empty, but the other one is
             return false;
-        } else if (this.size() > other.size()) {
-            // this set has more unique entries than the other set, so there's no way this can be satisfied.
-            return false;
         } else {
             // neither are empty, we need to compare the individual entries
-            Set<Map.Entry<String, String>> entries = this.map.entries();
+            Set<Map.Entry<String, Collection<String>>> entries = this.map.asMap().entrySet();
             synchronized (this.map) {
-                for (Map.Entry<String, String> e : entries) {
-                    if (!other.contains(e.getKey(), e.getValue())) {
+                for (Map.Entry<String, Collection<String>> e : entries) {
+                    if (!other.containsAny(e.getKey(), e.getValue())) {
                         return false;
                     }
                 }


### PR DESCRIPTION
The suggestion was:

> different contexts should be AND connected, but if its the same context, OR makes more sense

So that's what this does.

### Example
User has the following current contexts:
```
server=survival
world=overworld
gamemode=creative
wg-region=spawn
```

Previously, defining a node with contexts `server=survival world=overworld world=nether` would not have applied, as the user would have needed to be in:

> `server=factions` AND `world=overworld` AND `world=nether` (not possible).

However, with this change, the user needs to be in:

> `server=factions` AND (`world=overworld` OR `world=nether`) (possible!).

### Considerations

* Might break existing usages
* Would make us incompatible (technically) with the sponge context spec.

It could be put behind a config option, but my current thoughts are that it's quite a nice change, and we should just change it!

I can't think of a use case where the old behaviour (compared to what is being suggested here) would be useful, but happy to be proven wrong!

Would like to hear peoples thoughts. :))

@bloodmc @zml2008 I figure you might be interested ^^ as creators/heavy users of the contexts system, I'd appreciate any opinions/ideas you have if you'd like to share them 😊