### PR TITLE
Fix formatting issues

### DIFF
--- a/common/src/main/java/me/lucko/luckperms/common/locale/Message.java
+++ b/common/src/main/java/me/lucko/luckperms/common/locale/Message.java
@@ -98,7 +98,7 @@ public interface Message {
             .append(text()
                     .decoration(BOLD, true)
                     .append(text('L', AQUA))
-                    .append(text('P', DARK_GREEN))
+                    .append(text('P', DARK_AQUA))
             )
             .append(text(']'))
             .build();

--- a/common/src/main/java/me/lucko/luckperms/common/storage/implementation/mongodb/MongoStorage.java
+++ b/common/src/main/java/me/lucko/luckperms/common/storage/implementation/mongodb/MongoStorage.java
@@ -154,7 +154,7 @@ public class MongoStorage implements StorageImplementation {
         long duration = System.currentTimeMillis() - start;
 
         if (success) {
-            meta.put("Ping", "" + duration + "ms");
+            meta.put("Ping", duration + "ms");
             meta.put("Connected", "true");
         } else {
             meta.put("Connected", "false");

--- a/common/src/main/java/me/lucko/luckperms/common/storage/implementation/mongodb/MongoStorage.java
+++ b/common/src/main/java/me/lucko/luckperms/common/storage/implementation/mongodb/MongoStorage.java
@@ -154,7 +154,7 @@ public class MongoStorage implements StorageImplementation {
         long duration = System.currentTimeMillis() - start;
 
         if (success) {
-            meta.put("Ping", "&a" + duration + "ms");
+            meta.put("Ping", "" + duration + "ms");
             meta.put("Connected", "true");
         } else {
             meta.put("Connected", "false");

--- a/common/src/main/java/me/lucko/luckperms/common/storage/implementation/sql/connection/hikari/HikariConnectionFactory.java
+++ b/common/src/main/java/me/lucko/luckperms/common/storage/implementation/sql/connection/hikari/HikariConnectionFactory.java
@@ -134,7 +134,7 @@ public abstract class HikariConnectionFactory implements ConnectionFactory {
         long duration = System.currentTimeMillis() - start;
 
         if (success) {
-            meta.put("Ping", "&a" + duration + "ms");
+            meta.put("Ping", duration + "ms");
             meta.put("Connected", "true");
         } else {
             meta.put("Connected", "false");


### PR DESCRIPTION
- Fixes legacy `&a` in ping indicator for remote DBs in `/lp info` (#2670)

- Returns the prefix back to it's old Aqua/Dark Aqua