### PR TITLE
Fix bulk update SQL stats lookup bug

### DIFF
--- a/common/src/main/java/me/lucko/luckperms/common/bulkupdate/BulkUpdate.java
+++ b/common/src/main/java/me/lucko/luckperms/common/bulkupdate/BulkUpdate.java
@@ -103,6 +103,17 @@ public final class BulkUpdate {
         // (DELETE FROM or UPDATE)
         this.action.appendSql(builder);
 
+        return appendConstraintsAsSql(builder);
+    }
+
+    /**
+     * Appends the constraints of this {@link BulkUpdate} to the provided statement builder in SQL syntax
+     *
+     * @param builder the statement builder to append the constraints to
+     * @return the same statement builder provided as input
+     */
+    public PreparedStatementBuilder appendConstraintsAsSql(PreparedStatementBuilder builder) {
+
         // if there are no constraints, just return without a WHERE clause
         if (this.queries.isEmpty()) {
             return builder;

--- a/common/src/main/java/me/lucko/luckperms/common/storage/implementation/sql/SqlStorage.java
+++ b/common/src/main/java/me/lucko/luckperms/common/storage/implementation/sql/SqlStorage.java
@@ -261,10 +261,7 @@ public class SqlStorage implements StorageImplementation {
                     if (bulkUpdate.isTrackingStatistics()) {
                         PreparedStatementBuilder builder = new PreparedStatementBuilder();
                         builder.append(USER_PERMISSIONS_SELECT_DISTINCT);
-                        if (!bulkUpdate.getQueries().isEmpty()) {
-                            builder.append(" WHERE ");
-                            bulkUpdate.getQueries().forEach(query -> query.appendSql(builder));
-                        }
+                        bulkUpdate.appendConstraintsAsSql(builder);
 
                         try (PreparedStatement lookup = builder.build(c, this.statementProcessor)) {
                             try (ResultSet rs = lookup.executeQuery()) {
@@ -291,10 +288,7 @@ public class SqlStorage implements StorageImplementation {
                     if (bulkUpdate.isTrackingStatistics()) {
                         PreparedStatementBuilder builder = new PreparedStatementBuilder();
                         builder.append(GROUP_PERMISSIONS_SELECT_ALL);
-                        if (!bulkUpdate.getQueries().isEmpty()) {
-                            builder.append(" WHERE ");
-                            bulkUpdate.getQueries().forEach(query -> query.appendSql(builder));
-                        }
+                        bulkUpdate.appendConstraintsAsSql(builder);
 
                         try (PreparedStatement lookup = builder.build(c, this.statementProcessor)) {
                             try (ResultSet rs = lookup.executeQuery()) {


### PR DESCRIPTION
Fixes a bug for the bulk update command failing on SQL based storages when tracking operation stats with multiple constraints, making the "impact lookup" query `... WHERE field1 = 'value1'field2 = 'value2'field3 = 'value3' ...`