### PR TITLE
Substitute null check with Configuration#isSet

### DIFF
--- a/bukkit/src/main/java/me/lucko/luckperms/bukkit/BukkitConfigAdapter.java
+++ b/bukkit/src/main/java/me/lucko/luckperms/bukkit/BukkitConfigAdapter.java
@@ -72,7 +72,7 @@ public class BukkitConfigAdapter implements ConfigurationAdapter {
     @Override
     public List<String> getStringList(String path, List<String> def) {
         List<String> list = this.configuration.getStringList(path);
-        return list == null ? def : list;
+        return this.configuration.isSet(path) ? list : def;
     }
 
     @Override


### PR DESCRIPTION
Hi again! :)

**Change**
Configuration#getStringList(String) does never return null. Instead it returns a new list if one is absent from the file. This means that the fallback list will never be returned or used regardless. A change to make this work would be to return the fallback list if and only if Configuration#isSet(String) returns false. While we could use Configuration#isString(String) or Configuration#isList(String) both of them are quite pedantic. Let alone Configuration#getStringList(String) would convert a single config value to a singleton list. It would also convert a list of numbers to a list of strings. In conclusion Configuration#isSet(String) would be the only mandatory check required.