### PR TITLE
Fix millenary issue on SQL storage systems

### DIFF
--- a/common/src/main/java/me/lucko/luckperms/common/storage/implementation/sql/SqlStorage.java
+++ b/common/src/main/java/me/lucko/luckperms/common/storage/implementation/sql/SqlStorage.java
@@ -980,7 +980,7 @@ public class SqlStorage implements StorageImplementation {
     }
 
     private static boolean tableExists(Connection connection, String table) throws SQLException {
-        try (ResultSet rs = connection.getMetaData().getTables(null, null, "%", null)) {
+        try (ResultSet rs = connection.getMetaData().getTables(connection.getCatalog(), null, "%", null)) {
             while (rs.next()) {
                 if (rs.getString(3).equalsIgnoreCase(table)) {
                     return true;


### PR DESCRIPTION
Fixes #2842, #2774, and a number of duplicate issues where LP would not create the database tables even though it would connect properly (additionally, creating and leaving the `{prefix}messenger` table as the only table on the database); issue is it was scanning through the entirety of the sql server, so if another database on the same server already had the `{prefix}user_permissions` table, it would return true. Fixed by passing the catalog (essentially the db name) to the getTables query as "filter".

Tested on MariaDB and MySQL.