### PR TITLE
Added virtual host support for RabbitMQ

### DIFF
--- a/bukkit/src/main/resources/config.yml
+++ b/bukkit/src/main/resources/config.yml
@@ -253,6 +253,7 @@ redis:
 rabbitmq:
   enabled: false
   address: localhost
+  vhost: '/'
   username: 'guest'
   password: 'guest'
 

--- a/bungee/src/main/resources/config.yml
+++ b/bungee/src/main/resources/config.yml
@@ -251,6 +251,7 @@ redis:
 rabbitmq:
   enabled: false
   address: localhost
+  vhost: '/'
   username: 'guest'
   password: 'guest'
 

--- a/common/src/main/java/me/lucko/luckperms/common/config/ConfigKeys.java
+++ b/common/src/main/java/me/lucko/luckperms/common/config/ConfigKeys.java
@@ -630,6 +630,11 @@ public final class ConfigKeys {
     public static final ConfigKey<String> RABBITMQ_ADDRESS = notReloadable(stringKey("rabbitmq.address", null));
 
     /**
+     * The virtual host to be used by the rabbitmq server
+     */
+    public static final ConfigKey<String> RABBITMQ_VIRTUAL_HOST = notReloadable(stringKey("rabbitmq.vhost", "/"));
+
+    /**
      * The username in use by the rabbitmq server
      */
     public static final ConfigKey<String> RABBITMQ_USERNAME = notReloadable(stringKey("rabbitmq.username", "guest"));

--- a/common/src/main/java/me/lucko/luckperms/common/messaging/MessagingFactory.java
+++ b/common/src/main/java/me/lucko/luckperms/common/messaging/MessagingFactory.java
@@ -162,10 +162,11 @@ public class MessagingFactory<P extends LuckPermsPlugin> {
 
             LuckPermsConfiguration config = getPlugin().getConfiguration();
             String address = config.get(ConfigKeys.RABBITMQ_ADDRESS);
+            String virtualHost = config.get(ConfigKeys.RABBITMQ_VIRTUAL_HOST);
             String username = config.get(ConfigKeys.RABBITMQ_USERNAME);
             String password = config.get(ConfigKeys.RABBITMQ_PASSWORD);
 
-            rabbitmq.init(address, username, password);
+            rabbitmq.init(address, virtualHost, username, password);
             return rabbitmq;
         }
     }

--- a/common/src/main/java/me/lucko/luckperms/common/messaging/rabbitmq/RabbitMQMessenger.java
+++ b/common/src/main/java/me/lucko/luckperms/common/messaging/rabbitmq/RabbitMQMessenger.java
@@ -65,7 +65,7 @@ public class RabbitMQMessenger implements Messenger {
         this.consumer = consumer;
     }
 
-    public void init(String address, String username, String password) {
+    public void init(String address, String virtualHost, String username, String password) {
         String[] addressSplit = address.split(":");
         String host = addressSplit[0];
         int port = addressSplit.length > 1 ? Integer.parseInt(addressSplit[1]) : DEFAULT_PORT;
@@ -73,6 +73,7 @@ public class RabbitMQMessenger implements Messenger {
         this.connectionFactory = new ConnectionFactory();
         this.connectionFactory.setHost(host);
         this.connectionFactory.setPort(port);
+        this.connectionFactory.setVirtualHost(virtualHost);
         this.connectionFactory.setUsername(username);
         this.connectionFactory.setPassword(password);
 

--- a/fabric/src/main/resources/luckperms.conf
+++ b/fabric/src/main/resources/luckperms.conf
@@ -257,6 +257,7 @@ redis {
 rabbitmq {
   enabled = false
   address = "localhost"
+  vhost = "/"
   username = "guest"
   password = "guest"
 }

--- a/nukkit/src/main/resources/config.yml
+++ b/nukkit/src/main/resources/config.yml
@@ -248,6 +248,7 @@ redis:
 rabbitmq:
   enabled: false
   address: localhost
+  vhost: '/'
   username: 'guest'
   password: 'guest'
 

--- a/sponge/src/main/resources/luckperms.conf
+++ b/sponge/src/main/resources/luckperms.conf
@@ -257,6 +257,7 @@ redis {
 rabbitmq {
   enabled = false
   address = "localhost"
+  vhost = "/"
   username = "guest"
   password = "guest"
 }

--- a/velocity/src/main/resources/config.yml
+++ b/velocity/src/main/resources/config.yml
@@ -242,6 +242,7 @@ redis:
 rabbitmq:
   enabled: false
   address: localhost
+  vhost: '/'
   username: 'guest'
   password: 'guest'
 


### PR DESCRIPTION
Tested on latest BungeeCord (`git:BungeeCord-Bootstrap:1.16-R0.5-SNAPSHOT:3d701fb:1545`), no reason why it wouldn't work on any other system since the configs follow the format I found in them, and this is all in common rather than implementations. I will happily test it on all systems though on request.

Virtual hosts are used to split up things into different things basically (I'm not very good with explanations, see [here](https://www.rabbitmq.com/vhosts.html)), which allows you to isolate all your different projects that use it, so there's no interference.