### PR TITLE
Implement jar-in-jar loader system

### DIFF
--- a/bukkit-legacy/build.gradle
+++ b/bukkit-legacy/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-    compile project(path: ':bukkit', configuration: 'shadow')
+    compile project(path: ':bukkit:loader', configuration: 'shadow')
     compile 'com.google.code.gson:gson:2.7'
     compile 'com.google.guava:guava:19.0'
 }
@@ -12,7 +12,6 @@ shadowJar {
     archiveName = "LuckPerms-Bukkit-Legacy-${project.ext.fullVersion}.jar"
 
     dependencies {
-        include(dependency('net.luckperms:.*'))
         include(dependency('me.lucko.luckperms:.*'))
         include(dependency('com.google.guava:guava:.*'))
         include(dependency('com.google.code.gson:gson:.*'))

--- a/bukkit/build.gradle
+++ b/bukkit/build.gradle
@@ -21,7 +21,7 @@ dependencies {
 }
 
 shadowJar {
-    archiveName = "luckperms-bukkit.innerjar"
+    archiveName = 'luckperms-bukkit.jarinjar'
 
     dependencies {
         include(dependency('me.lucko.luckperms:.*'))

--- a/bukkit/build.gradle
+++ b/bukkit/build.gradle
@@ -9,6 +9,7 @@ repositories {
 
 dependencies {
     compile project(':common')
+    compileOnly project(':common:loader-utils')
 
     compileOnly 'com.destroystokyo.paper:paper-api:1.15.2-R0.1-SNAPSHOT'
     compileOnly 'me.lucko:adventure-platform-bukkit:4.0.0' // re: this artifact - see note in common/build.gradle
@@ -19,18 +20,10 @@ dependencies {
     compileOnly 'lilypad.client.connect:api:0.0.1-SNAPSHOT'
 }
 
-processResources {
-    from(sourceSets.main.resources.srcDirs) {
-        expand 'pluginVersion': project.ext.fullVersion
-        include 'plugin.yml'
-    }
-}
-
 shadowJar {
-    archiveName = "LuckPerms-Bukkit-${project.ext.fullVersion}.jar"
+    archiveName = "luckperms-bukkit.innerjar"
 
     dependencies {
-        include(dependency('net.luckperms:.*'))
         include(dependency('me.lucko.luckperms:.*'))
     }
 

--- a/bukkit/loader/build.gradle
+++ b/bukkit/loader/build.gradle
@@ -1,0 +1,33 @@
+plugins {
+    id 'com.github.johnrengelman.shadow'
+}
+
+repositories {
+    maven { url 'https://papermc.io/repo/repository/maven-public/' }
+}
+
+dependencies {
+    compileOnly 'com.destroystokyo.paper:paper-api:1.15.2-R0.1-SNAPSHOT'
+
+    compile project(':api')
+    compile project(':common:loader-utils')
+}
+
+processResources {
+    from(sourceSets.main.resources.srcDirs) {
+        expand 'pluginVersion': project.ext.fullVersion
+        include 'plugin.yml'
+    }
+}
+
+shadowJar {
+    archiveName = "LuckPerms-Bukkit-${project.ext.fullVersion}.jar"
+
+    from {
+        project(':bukkit').tasks.shadowJar.archiveFile
+    }
+}
+
+artifacts {
+    archives shadowJar
+}

--- a/bukkit/loader/src/main/java/me/lucko/luckperms/bukkit/loader/BukkitLoaderPlugin.java
+++ b/bukkit/loader/src/main/java/me/lucko/luckperms/bukkit/loader/BukkitLoaderPlugin.java
@@ -23,15 +23,37 @@
  *  SOFTWARE.
  */
 
-package me.lucko.luckperms.common.dependencies.classloader;
+package me.lucko.luckperms.bukkit.loader;
 
-import java.nio.file.Path;
+import me.lucko.luckperms.common.loader.JarInJarClassLoader;
+import me.lucko.luckperms.common.loader.LoaderBootstrap;
 
-/**
- * Represents the plugins classloader
- */
-public interface PluginClassLoader {
+import org.bukkit.plugin.java.JavaPlugin;
 
-    void addJarToClasspath(Path file);
+public class BukkitLoaderPlugin extends JavaPlugin {
+    private static final String JAR_NAME = "luckperms-bukkit.innerjar";
+    private static final String BOOTSTRAP_CLASS = "me.lucko.luckperms.bukkit.LPBukkitBootstrap";
+
+    private final LoaderBootstrap plugin;
+
+    public BukkitLoaderPlugin() {
+        JarInJarClassLoader loader = new JarInJarClassLoader(getClassLoader(), JAR_NAME);
+        this.plugin = loader.instantiatePlugin(BOOTSTRAP_CLASS, JavaPlugin.class, this);
+    }
+
+    @Override
+    public void onLoad() {
+        this.plugin.onLoad();
+    }
+
+    @Override
+    public void onEnable() {
+        this.plugin.onEnable();
+    }
+
+    @Override
+    public void onDisable() {
+        this.plugin.onDisable();
+    }
 
 }

--- a/bukkit/loader/src/main/resources/plugin.yml
+++ b/bukkit/loader/src/main/resources/plugin.yml
@@ -3,7 +3,7 @@ version: ${pluginVersion}
 description: A permissions plugin
 author: Luck
 website: https://luckperms.net
-main: me.lucko.luckperms.bukkit.LPBukkitBootstrap
+main: me.lucko.luckperms.bukkit.loader.BukkitLoaderPlugin
 load: STARTUP
 
 # Mark the plugin as 1.13 compatible to avoid CB having to perform quite as much unnecessary

--- a/bukkit/src/main/java/me/lucko/luckperms/bukkit/BukkitCommandExecutor.java
+++ b/bukkit/src/main/java/me/lucko/luckperms/bukkit/BukkitCommandExecutor.java
@@ -73,7 +73,7 @@ public class BukkitCommandExecutor extends CommandManager implements TabExecutor
     public void register() {
         this.command.setExecutor(this);
         this.command.setTabCompleter(this);
-        this.plugin.getBootstrap().getServer().getPluginManager().registerEvents(this, this.plugin.getBootstrap().getLoader());
+        this.plugin.getBootstrap().getServer().getPluginManager().registerEvents(this, this.plugin.getLoader());
     }
 
     @Override

--- a/bukkit/src/main/java/me/lucko/luckperms/bukkit/BukkitCommandExecutor.java
+++ b/bukkit/src/main/java/me/lucko/luckperms/bukkit/BukkitCommandExecutor.java
@@ -73,7 +73,7 @@ public class BukkitCommandExecutor extends CommandManager implements TabExecutor
     public void register() {
         this.command.setExecutor(this);
         this.command.setTabCompleter(this);
-        this.plugin.getBootstrap().getServer().getPluginManager().registerEvents(this, this.plugin.getBootstrap());
+        this.plugin.getBootstrap().getServer().getPluginManager().registerEvents(this, this.plugin.getBootstrap().getLoader());
     }
 
     @Override

--- a/bukkit/src/main/java/me/lucko/luckperms/bukkit/BukkitEventBus.java
+++ b/bukkit/src/main/java/me/lucko/luckperms/bukkit/BukkitEventBus.java
@@ -39,7 +39,7 @@ public class BukkitEventBus extends AbstractEventBus<Plugin> implements Listener
 
         // register listener
         LPBukkitBootstrap bootstrap = plugin.getBootstrap();
-        bootstrap.getServer().getPluginManager().registerEvents(this, bootstrap);
+        bootstrap.getServer().getPluginManager().registerEvents(this, bootstrap.getLoader());
     }
 
     @Override

--- a/bukkit/src/main/java/me/lucko/luckperms/bukkit/BukkitSenderFactory.java
+++ b/bukkit/src/main/java/me/lucko/luckperms/bukkit/BukkitSenderFactory.java
@@ -44,7 +44,7 @@ public class BukkitSenderFactory extends SenderFactory<LPBukkitPlugin, CommandSe
 
     public BukkitSenderFactory(LPBukkitPlugin plugin) {
         super(plugin);
-        this.audiences = BukkitAudiences.create(plugin.getBootstrap());
+        this.audiences = BukkitAudiences.create(plugin.getBootstrap().getLoader());
     }
 
     @Override

--- a/bukkit/src/main/java/me/lucko/luckperms/bukkit/BukkitSenderFactory.java
+++ b/bukkit/src/main/java/me/lucko/luckperms/bukkit/BukkitSenderFactory.java
@@ -44,7 +44,7 @@ public class BukkitSenderFactory extends SenderFactory<LPBukkitPlugin, CommandSe
 
     public BukkitSenderFactory(LPBukkitPlugin plugin) {
         super(plugin);
-        this.audiences = BukkitAudiences.create(plugin.getBootstrap().getLoader());
+        this.audiences = BukkitAudiences.create(plugin.getLoader());
     }
 
     @Override

--- a/bukkit/src/main/java/me/lucko/luckperms/bukkit/LPBukkitBootstrap.java
+++ b/bukkit/src/main/java/me/lucko/luckperms/bukkit/LPBukkitBootstrap.java
@@ -112,7 +112,7 @@ public class LPBukkitBootstrap implements LuckPermsBootstrap, LoaderBootstrap {
     // provide adapters
 
     public JavaPlugin getLoader() {
-        return loader;
+        return this.loader;
     }
 
     public Server getServer() {
@@ -156,7 +156,7 @@ public class LPBukkitBootstrap implements LuckPermsBootstrap, LoaderBootstrap {
     @Override
     public void onEnable() {
         if (this.incompatibleVersion) {
-            Logger logger = loader.getLogger();
+            Logger logger = this.loader.getLogger();
             logger.severe("----------------------------------------------------------------------");
             logger.severe("Your server version is not compatible with this build of LuckPerms. :(");
             logger.severe("");

--- a/bukkit/src/main/java/me/lucko/luckperms/bukkit/LPBukkitPlugin.java
+++ b/bukkit/src/main/java/me/lucko/luckperms/bukkit/LPBukkitPlugin.java
@@ -74,7 +74,6 @@ import org.bukkit.permissions.PermissionDefault;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.ServicePriority;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -127,14 +126,14 @@ public class LPBukkitPlugin extends AbstractLuckPermsPlugin {
 
     @Override
     protected ConfigurationAdapter provideConfigurationAdapter() {
-        return new BukkitConfigAdapter(this, resolveConfig());
+        return new BukkitConfigAdapter(this, resolveConfig("config.yml").toFile());
     }
 
     @Override
     protected void registerPlatformListeners() {
         this.connectionListener = new BukkitConnectionListener(this);
-        this.bootstrap.getServer().getPluginManager().registerEvents(this.connectionListener, this.bootstrap);
-        this.bootstrap.getServer().getPluginManager().registerEvents(new BukkitPlatformListener(this), this.bootstrap);
+        this.bootstrap.getServer().getPluginManager().registerEvents(this.connectionListener, this.bootstrap.getLoader());
+        this.bootstrap.getServer().getPluginManager().registerEvents(new BukkitPlatformListener(this), this.bootstrap.getLoader());
     }
 
     @Override
@@ -144,7 +143,7 @@ public class LPBukkitPlugin extends AbstractLuckPermsPlugin {
 
     @Override
     protected void registerCommands() {
-        PluginCommand command = this.bootstrap.getCommand("luckperms");
+        PluginCommand command = this.bootstrap.getLoader().getCommand("luckperms");
         if (command == null) {
             getLogger().severe("Unable to register /luckperms command with the server");
             return;
@@ -187,7 +186,7 @@ public class LPBukkitPlugin extends AbstractLuckPermsPlugin {
         this.contextManager = new BukkitContextManager(this);
 
         BukkitPlayerCalculator playerCalculator = new BukkitPlayerCalculator(this);
-        this.bootstrap.getServer().getPluginManager().registerEvents(playerCalculator, this.bootstrap);
+        this.bootstrap.getServer().getPluginManager().registerEvents(playerCalculator, this.bootstrap.getLoader());
         this.contextManager.registerCalculator(playerCalculator);
     }
 
@@ -206,7 +205,7 @@ public class LPBukkitPlugin extends AbstractLuckPermsPlugin {
 
             // schedule another injection after all plugins have loaded
             // the entire pluginmanager instance is replaced by some plugins :(
-            this.bootstrap.getServer().getScheduler().runTaskLaterAsynchronously(this.bootstrap, injector, 1);
+            this.bootstrap.getServer().getScheduler().runTaskLaterAsynchronously(this.bootstrap.getLoader(), injector, 1);
         }
 
         /*
@@ -221,7 +220,7 @@ public class LPBukkitPlugin extends AbstractLuckPermsPlugin {
          * - https://hub.spigotmc.org/jira/browse/SPIGOT-5546
          * - https://github.com/PaperMC/Paper/pull/3509
          */
-        PluginManagerUtil.injectDependency(this.bootstrap.getServer().getPluginManager(), this.bootstrap.getName(), "Vault");
+        PluginManagerUtil.injectDependency(this.bootstrap.getServer().getPluginManager(), this.bootstrap.getLoader().getName(), "Vault");
 
         // Provide vault support
         tryVaultHook(false);
@@ -251,7 +250,7 @@ public class LPBukkitPlugin extends AbstractLuckPermsPlugin {
 
     @Override
     protected void registerApiOnPlatform(LuckPerms api) {
-        this.bootstrap.getServer().getServicesManager().register(LuckPerms.class, api, this.bootstrap, ServicePriority.Normal);
+        this.bootstrap.getServer().getServicesManager().register(LuckPerms.class, api, this.bootstrap.getLoader(), ServicePriority.Normal);
     }
 
     @Override
@@ -276,7 +275,7 @@ public class LPBukkitPlugin extends AbstractLuckPermsPlugin {
 
         // remove all operators on startup if they're disabled
         if (!getConfiguration().get(ConfigKeys.OPS_ENABLED)) {
-            this.bootstrap.getServer().getScheduler().runTaskAsynchronously(this.bootstrap, () -> {
+            this.bootstrap.getServer().getScheduler().runTaskAsynchronously(this.bootstrap.getLoader(), () -> {
                 for (OfflinePlayer player : this.bootstrap.getServer().getOperators()) {
                     player.setOp(false);
                 }
@@ -349,15 +348,6 @@ public class LPBukkitPlugin extends AbstractLuckPermsPlugin {
         if (this.vaultHookManager != null) {
             this.vaultHookManager.unhook();
         }
-    }
-
-    private File resolveConfig() {
-        File configFile = new File(this.bootstrap.getDataFolder(), "config.yml");
-        if (!configFile.exists()) {
-            this.bootstrap.getDataFolder().mkdirs();
-            this.bootstrap.saveResource("config.yml", false);
-        }
-        return configFile;
     }
 
     private static boolean classExists(String className) {

--- a/bukkit/src/main/java/me/lucko/luckperms/bukkit/LPBukkitPlugin.java
+++ b/bukkit/src/main/java/me/lucko/luckperms/bukkit/LPBukkitPlugin.java
@@ -73,6 +73,7 @@ import org.bukkit.permissions.Permission;
 import org.bukkit.permissions.PermissionDefault;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.ServicePriority;
+import org.bukkit.plugin.java.JavaPlugin;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -106,6 +107,10 @@ public class LPBukkitPlugin extends AbstractLuckPermsPlugin {
     @Override
     public LPBukkitBootstrap getBootstrap() {
         return this.bootstrap;
+    }
+
+    public JavaPlugin getLoader() {
+        return this.bootstrap.getLoader();
     }
 
     @Override

--- a/bukkit/src/main/java/me/lucko/luckperms/bukkit/brigadier/LuckPermsBrigadier.java
+++ b/bukkit/src/main/java/me/lucko/luckperms/bukkit/brigadier/LuckPermsBrigadier.java
@@ -44,7 +44,7 @@ public final class LuckPermsBrigadier {
     private LuckPermsBrigadier() {}
 
     public static void register(LPBukkitPlugin plugin, Command pluginCommand) throws Exception {
-        Commodore commodore = CommodoreProvider.getCommodore(plugin.getBootstrap().getLoader());
+        Commodore commodore = CommodoreProvider.getCommodore(plugin.getLoader());
         try (InputStream is = plugin.getBootstrap().getResourceStream("luckperms.commodore")) {
             if (is == null) {
                 throw new Exception("Brigadier command data missing from jar");

--- a/bukkit/src/main/java/me/lucko/luckperms/bukkit/brigadier/LuckPermsBrigadier.java
+++ b/bukkit/src/main/java/me/lucko/luckperms/bukkit/brigadier/LuckPermsBrigadier.java
@@ -44,7 +44,7 @@ public final class LuckPermsBrigadier {
     private LuckPermsBrigadier() {}
 
     public static void register(LPBukkitPlugin plugin, Command pluginCommand) throws Exception {
-        Commodore commodore = CommodoreProvider.getCommodore(plugin.getBootstrap());
+        Commodore commodore = CommodoreProvider.getCommodore(plugin.getBootstrap().getLoader());
         try (InputStream is = plugin.getBootstrap().getResourceStream("luckperms.commodore")) {
             if (is == null) {
                 throw new Exception("Brigadier command data missing from jar");

--- a/bukkit/src/main/java/me/lucko/luckperms/bukkit/inject/permissible/LuckPermsPermissionAttachment.java
+++ b/bukkit/src/main/java/me/lucko/luckperms/bukkit/inject/permissible/LuckPermsPermissionAttachment.java
@@ -287,7 +287,7 @@ public class LuckPermsPermissionAttachment extends PermissionAttachment {
 
     @Override
     public @NonNull Plugin getPlugin() {
-        return this.owner != null ? this.owner : this.permissible.getPlugin().getBootstrap();
+        return this.owner != null ? this.owner : this.permissible.getPlugin().getBootstrap().getLoader();
     }
 
     @Override

--- a/bukkit/src/main/java/me/lucko/luckperms/bukkit/inject/permissible/LuckPermsPermissionAttachment.java
+++ b/bukkit/src/main/java/me/lucko/luckperms/bukkit/inject/permissible/LuckPermsPermissionAttachment.java
@@ -287,7 +287,7 @@ public class LuckPermsPermissionAttachment extends PermissionAttachment {
 
     @Override
     public @NonNull Plugin getPlugin() {
-        return this.owner != null ? this.owner : this.permissible.getPlugin().getBootstrap().getLoader();
+        return this.owner != null ? this.owner : this.permissible.getPlugin().getLoader();
     }
 
     @Override

--- a/bukkit/src/main/java/me/lucko/luckperms/bukkit/listeners/BukkitConnectionListener.java
+++ b/bukkit/src/main/java/me/lucko/luckperms/bukkit/listeners/BukkitConnectionListener.java
@@ -239,7 +239,7 @@ public class BukkitConnectionListener extends AbstractConnectionListener impleme
 
         // perform unhooking from bukkit objects 1 tick later.
         // this allows plugins listening after us on MONITOR to still have intact permissions data
-        this.plugin.getBootstrap().getServer().getScheduler().runTaskLater(this.plugin.getBootstrap(), () -> {
+        this.plugin.getBootstrap().getServer().getScheduler().runTaskLater(this.plugin.getBootstrap().getLoader(), () -> {
             // Remove the custom permissible
             try {
                 PermissibleInjector.uninject(player, true);

--- a/bukkit/src/main/java/me/lucko/luckperms/bukkit/listeners/BukkitConnectionListener.java
+++ b/bukkit/src/main/java/me/lucko/luckperms/bukkit/listeners/BukkitConnectionListener.java
@@ -239,7 +239,7 @@ public class BukkitConnectionListener extends AbstractConnectionListener impleme
 
         // perform unhooking from bukkit objects 1 tick later.
         // this allows plugins listening after us on MONITOR to still have intact permissions data
-        this.plugin.getBootstrap().getServer().getScheduler().runTaskLater(this.plugin.getBootstrap().getLoader(), () -> {
+        this.plugin.getBootstrap().getServer().getScheduler().runTaskLater(this.plugin.getLoader(), () -> {
             // Remove the custom permissible
             try {
                 PermissibleInjector.uninject(player, true);

--- a/bukkit/src/main/java/me/lucko/luckperms/bukkit/messaging/PluginMessageMessenger.java
+++ b/bukkit/src/main/java/me/lucko/luckperms/bukkit/messaging/PluginMessageMessenger.java
@@ -58,14 +58,14 @@ public class PluginMessageMessenger implements Messenger, PluginMessageListener 
     }
 
     public void init() {
-        this.plugin.getBootstrap().getServer().getMessenger().registerOutgoingPluginChannel(this.plugin.getBootstrap(), CHANNEL);
-        this.plugin.getBootstrap().getServer().getMessenger().registerIncomingPluginChannel(this.plugin.getBootstrap(), CHANNEL, this);
+        this.plugin.getBootstrap().getServer().getMessenger().registerOutgoingPluginChannel(this.plugin.getBootstrap().getLoader(), CHANNEL);
+        this.plugin.getBootstrap().getServer().getMessenger().registerIncomingPluginChannel(this.plugin.getBootstrap().getLoader(), CHANNEL, this);
     }
 
     @Override
     public void close() {
-        this.plugin.getBootstrap().getServer().getMessenger().unregisterIncomingPluginChannel(this.plugin.getBootstrap(), CHANNEL);
-        this.plugin.getBootstrap().getServer().getMessenger().unregisterOutgoingPluginChannel(this.plugin.getBootstrap(), CHANNEL);
+        this.plugin.getBootstrap().getServer().getMessenger().unregisterIncomingPluginChannel(this.plugin.getBootstrap().getLoader(), CHANNEL);
+        this.plugin.getBootstrap().getServer().getMessenger().unregisterOutgoingPluginChannel(this.plugin.getBootstrap().getLoader(), CHANNEL);
     }
 
     @Override
@@ -83,10 +83,10 @@ public class PluginMessageMessenger implements Messenger, PluginMessageListener 
                     return;
                 }
 
-                p.sendPluginMessage(PluginMessageMessenger.this.plugin.getBootstrap(), CHANNEL, data);
+                p.sendPluginMessage(PluginMessageMessenger.this.plugin.getBootstrap().getLoader(), CHANNEL, data);
                 cancel();
             }
-        }.runTaskTimer(this.plugin.getBootstrap(), 1L, 100L);
+        }.runTaskTimer(this.plugin.getBootstrap().getLoader(), 1L, 100L);
     }
 
     @Override

--- a/bukkit/src/main/java/me/lucko/luckperms/bukkit/messaging/PluginMessageMessenger.java
+++ b/bukkit/src/main/java/me/lucko/luckperms/bukkit/messaging/PluginMessageMessenger.java
@@ -58,14 +58,14 @@ public class PluginMessageMessenger implements Messenger, PluginMessageListener 
     }
 
     public void init() {
-        this.plugin.getBootstrap().getServer().getMessenger().registerOutgoingPluginChannel(this.plugin.getBootstrap().getLoader(), CHANNEL);
-        this.plugin.getBootstrap().getServer().getMessenger().registerIncomingPluginChannel(this.plugin.getBootstrap().getLoader(), CHANNEL, this);
+        this.plugin.getBootstrap().getServer().getMessenger().registerOutgoingPluginChannel(this.plugin.getLoader(), CHANNEL);
+        this.plugin.getBootstrap().getServer().getMessenger().registerIncomingPluginChannel(this.plugin.getLoader(), CHANNEL, this);
     }
 
     @Override
     public void close() {
-        this.plugin.getBootstrap().getServer().getMessenger().unregisterIncomingPluginChannel(this.plugin.getBootstrap().getLoader(), CHANNEL);
-        this.plugin.getBootstrap().getServer().getMessenger().unregisterOutgoingPluginChannel(this.plugin.getBootstrap().getLoader(), CHANNEL);
+        this.plugin.getBootstrap().getServer().getMessenger().unregisterIncomingPluginChannel(this.plugin.getLoader(), CHANNEL);
+        this.plugin.getBootstrap().getServer().getMessenger().unregisterOutgoingPluginChannel(this.plugin.getLoader(), CHANNEL);
     }
 
     @Override
@@ -83,10 +83,10 @@ public class PluginMessageMessenger implements Messenger, PluginMessageListener 
                     return;
                 }
 
-                p.sendPluginMessage(PluginMessageMessenger.this.plugin.getBootstrap().getLoader(), CHANNEL, data);
+                p.sendPluginMessage(PluginMessageMessenger.this.plugin.getLoader(), CHANNEL, data);
                 cancel();
             }
-        }.runTaskTimer(this.plugin.getBootstrap().getLoader(), 1L, 100L);
+        }.runTaskTimer(this.plugin.getLoader(), 1L, 100L);
     }
 
     @Override

--- a/bukkit/src/main/java/me/lucko/luckperms/bukkit/vault/VaultHookManager.java
+++ b/bukkit/src/main/java/me/lucko/luckperms/bukkit/vault/VaultHookManager.java
@@ -61,8 +61,8 @@ public class VaultHookManager {
             }
 
             final ServicesManager sm = this.plugin.getBootstrap().getServer().getServicesManager();
-            sm.register(Permission.class, this.permission, this.plugin.getBootstrap(), ServicePriority.High);
-            sm.register(Chat.class, this.chat, this.plugin.getBootstrap(), ServicePriority.High);
+            sm.register(Permission.class, this.permission, this.plugin.getBootstrap().getLoader(), ServicePriority.High);
+            sm.register(Chat.class, this.chat, this.plugin.getBootstrap().getLoader(), ServicePriority.High);
 
         } catch (Exception e) {
             this.plugin.getLogger().severe("Error occurred whilst hooking into Vault.", e);

--- a/bukkit/src/main/java/me/lucko/luckperms/bukkit/vault/VaultHookManager.java
+++ b/bukkit/src/main/java/me/lucko/luckperms/bukkit/vault/VaultHookManager.java
@@ -61,8 +61,8 @@ public class VaultHookManager {
             }
 
             final ServicesManager sm = this.plugin.getBootstrap().getServer().getServicesManager();
-            sm.register(Permission.class, this.permission, this.plugin.getBootstrap().getLoader(), ServicePriority.High);
-            sm.register(Chat.class, this.chat, this.plugin.getBootstrap().getLoader(), ServicePriority.High);
+            sm.register(Permission.class, this.permission, this.plugin.getLoader(), ServicePriority.High);
+            sm.register(Chat.class, this.chat, this.plugin.getLoader(), ServicePriority.High);
 
         } catch (Exception e) {
             this.plugin.getLogger().severe("Error occurred whilst hooking into Vault.", e);

--- a/bungee/build.gradle
+++ b/bungee/build.gradle
@@ -4,24 +4,17 @@ plugins {
 
 dependencies {
     compile project(':common')
+    compileOnly project(':common:loader-utils')
 
     compileOnly 'net.md-5:bungeecord-api:1.15-SNAPSHOT'
     compileOnly 'me.lucko:adventure-platform-bungeecord:4.0.0' // re: this artifact - see note in common/build.gradle
     compileOnly 'com.imaginarycode.minecraft:RedisBungee:0.4'
 }
 
-processResources {
-    from(sourceSets.main.resources.srcDirs) {
-        expand 'pluginVersion': project.ext.fullVersion
-        include 'plugin.yml'
-    }
-}
-
 shadowJar {
-    archiveName = "LuckPerms-Bungee-${project.ext.fullVersion}.jar"
+    archiveName = 'luckperms-bungee.jarinjar'
 
     dependencies {
-        include(dependency('net.luckperms:.*'))
         include(dependency('me.lucko.luckperms:.*'))
     }
 

--- a/bungee/loader/build.gradle
+++ b/bungee/loader/build.gradle
@@ -1,0 +1,29 @@
+plugins {
+    id 'com.github.johnrengelman.shadow'
+}
+
+dependencies {
+    compileOnly 'net.md-5:bungeecord-api:1.15-SNAPSHOT'
+
+    compile project(':api')
+    compile project(':common:loader-utils')
+}
+
+processResources {
+    from(sourceSets.main.resources.srcDirs) {
+        expand 'pluginVersion': project.ext.fullVersion
+        include 'plugin.yml'
+    }
+}
+
+shadowJar {
+    archiveName = "LuckPerms-Bungee-${project.ext.fullVersion}.jar"
+
+    from {
+        project(':bungee').tasks.shadowJar.archiveFile
+    }
+}
+
+artifacts {
+    archives shadowJar
+}

--- a/bungee/loader/src/main/java/me/lucko/luckperms/bungee/loader/BungeeLoaderPlugin.java
+++ b/bungee/loader/src/main/java/me/lucko/luckperms/bungee/loader/BungeeLoaderPlugin.java
@@ -23,22 +23,22 @@
  *  SOFTWARE.
  */
 
-package me.lucko.luckperms.bukkit.loader;
+package me.lucko.luckperms.bungee.loader;
 
 import me.lucko.luckperms.common.loader.JarInJarClassLoader;
 import me.lucko.luckperms.common.loader.LoaderBootstrap;
 
-import org.bukkit.plugin.java.JavaPlugin;
+import net.md_5.bungee.api.plugin.Plugin;
 
-public class BukkitLoaderPlugin extends JavaPlugin {
-    private static final String JAR_NAME = "luckperms-bukkit.jarinjar";
-    private static final String BOOTSTRAP_CLASS = "me.lucko.luckperms.bukkit.LPBukkitBootstrap";
+public class BungeeLoaderPlugin extends Plugin {
+    private static final String JAR_NAME = "luckperms-bungee.jarinjar";
+    private static final String BOOTSTRAP_CLASS = "me.lucko.luckperms.bungee.LPBungeeBootstrap";
 
     private final LoaderBootstrap plugin;
 
-    public BukkitLoaderPlugin() {
+    public BungeeLoaderPlugin() {
         JarInJarClassLoader loader = new JarInJarClassLoader(getClass().getClassLoader(), JAR_NAME);
-        this.plugin = loader.instantiatePlugin(BOOTSTRAP_CLASS, JavaPlugin.class, this);
+        this.plugin = loader.instantiatePlugin(BOOTSTRAP_CLASS, Plugin.class, this);
     }
 
     @Override

--- a/bungee/loader/src/main/resources/plugin.yml
+++ b/bungee/loader/src/main/resources/plugin.yml
@@ -2,5 +2,5 @@ name: LuckPerms
 version: ${pluginVersion}
 description: A permissions plugin
 author: Luck
-main: me.lucko.luckperms.bungee.LPBungeeBootstrap
+main: me.lucko.luckperms.bungee.loader.BungeeLoaderPlugin
 softDepends: ["RedisBungee"]

--- a/bungee/src/main/java/me/lucko/luckperms/bungee/BungeeCommandExecutor.java
+++ b/bungee/src/main/java/me/lucko/luckperms/bungee/BungeeCommandExecutor.java
@@ -73,7 +73,7 @@ public class BungeeCommandExecutor extends Command implements TabExecutor {
 
     public void register() {
         ProxyServer proxy = this.plugin.getBootstrap().getProxy();
-        proxy.getPluginManager().registerCommand(this.plugin.getBootstrap(), this);
+        proxy.getPluginManager().registerCommand(this.plugin.getLoader(), this);
 
         // don't allow players to execute the slash aliases - these are just for the console.
         proxy.getDisabledCommands().addAll(Arrays.asList(SLASH_ALIASES));

--- a/bungee/src/main/java/me/lucko/luckperms/bungee/BungeeSchedulerAdapter.java
+++ b/bungee/src/main/java/me/lucko/luckperms/bungee/BungeeSchedulerAdapter.java
@@ -45,7 +45,7 @@ public class BungeeSchedulerAdapter implements SchedulerAdapter {
 
     public BungeeSchedulerAdapter(LPBungeeBootstrap bootstrap) {
         this.bootstrap = bootstrap;
-        this.executor = r -> bootstrap.getProxy().getScheduler().runAsync(bootstrap, r);
+        this.executor = r -> bootstrap.getProxy().getScheduler().runAsync(bootstrap.getLoader(), r);
     }
 
     @Override
@@ -60,14 +60,14 @@ public class BungeeSchedulerAdapter implements SchedulerAdapter {
 
     @Override
     public SchedulerTask asyncLater(Runnable task, long delay, TimeUnit unit) {
-        ScheduledTask t = this.bootstrap.getProxy().getScheduler().schedule(this.bootstrap, task, delay, unit);
+        ScheduledTask t = this.bootstrap.getProxy().getScheduler().schedule(this.bootstrap.getLoader(), task, delay, unit);
         this.tasks.add(t);
         return t::cancel;
     }
 
     @Override
     public SchedulerTask asyncRepeating(Runnable task, long interval, TimeUnit unit) {
-        ScheduledTask t = this.bootstrap.getProxy().getScheduler().schedule(this.bootstrap, task, interval, interval, unit);
+        ScheduledTask t = this.bootstrap.getProxy().getScheduler().schedule(this.bootstrap.getLoader(), task, interval, interval, unit);
         this.tasks.add(t);
         return t::cancel;
     }

--- a/bungee/src/main/java/me/lucko/luckperms/bungee/BungeeSenderFactory.java
+++ b/bungee/src/main/java/me/lucko/luckperms/bungee/BungeeSenderFactory.java
@@ -42,7 +42,7 @@ public class BungeeSenderFactory extends SenderFactory<LPBungeePlugin, CommandSe
 
     public BungeeSenderFactory(LPBungeePlugin plugin) {
         super(plugin);
-        this.audiences = BungeeAudiences.create(plugin.getBootstrap());
+        this.audiences = BungeeAudiences.create(plugin.getLoader());
     }
 
     @Override

--- a/bungee/src/main/java/me/lucko/luckperms/bungee/LPBungeeBootstrap.java
+++ b/bungee/src/main/java/me/lucko/luckperms/bungee/LPBungeeBootstrap.java
@@ -26,9 +26,9 @@
 package me.lucko.luckperms.bungee;
 
 import me.lucko.luckperms.bungee.util.RedisBungeeUtil;
-import me.lucko.luckperms.common.dependencies.classloader.PluginClassLoader;
-import me.lucko.luckperms.common.dependencies.classloader.ReflectionClassLoader;
 import me.lucko.luckperms.common.plugin.bootstrap.LuckPermsBootstrap;
+import me.lucko.luckperms.common.plugin.classpath.ClassPathAppender;
+import me.lucko.luckperms.common.plugin.classpath.ReflectionClassPathAppender;
 import me.lucko.luckperms.common.plugin.logging.JavaPluginLogger;
 import me.lucko.luckperms.common.plugin.logging.PluginLogger;
 import me.lucko.luckperms.common.plugin.scheduler.SchedulerAdapter;
@@ -40,7 +40,6 @@ import net.md_5.bungee.api.plugin.PluginDescription;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.nio.file.Path;
 import java.time.Instant;
@@ -67,9 +66,9 @@ public class LPBungeeBootstrap extends Plugin implements LuckPermsBootstrap {
     private final SchedulerAdapter schedulerAdapter;
 
     /**
-     * The plugin classloader
+     * The plugin class path appender
      */
-    private final PluginClassLoader classLoader;
+    private final ClassPathAppender classPathAppender;
 
     /**
      * The plugin instance
@@ -90,7 +89,7 @@ public class LPBungeeBootstrap extends Plugin implements LuckPermsBootstrap {
 
     public LPBungeeBootstrap() {
         this.schedulerAdapter = new BungeeSchedulerAdapter(this);
-        this.classLoader = new ReflectionClassLoader(this);
+        this.classPathAppender = new ReflectionClassPathAppender(this);
         this.plugin = new LPBungeePlugin(this);
     }
 
@@ -110,8 +109,8 @@ public class LPBungeeBootstrap extends Plugin implements LuckPermsBootstrap {
     }
 
     @Override
-    public PluginClassLoader getPluginClassLoader() {
-        return this.classLoader;
+    public ClassPathAppender getClassPathAppender() {
+        return this.classPathAppender;
     }
 
     // lifecycle
@@ -208,11 +207,6 @@ public class LPBungeeBootstrap extends Plugin implements LuckPermsBootstrap {
     @Override
     public Path getDataDirectory() {
         return getDataFolder().toPath().toAbsolutePath();
-    }
-
-    @Override
-    public InputStream getResourceStream(String path) {
-        return getResourceAsStream(path);
     }
 
     @Override

--- a/bungee/src/main/java/me/lucko/luckperms/bungee/LPBungeePlugin.java
+++ b/bungee/src/main/java/me/lucko/luckperms/bungee/LPBungeePlugin.java
@@ -52,10 +52,6 @@ import me.lucko.luckperms.common.tasks.ExpireTemporaryTask;
 import net.luckperms.api.LuckPerms;
 import net.luckperms.api.query.QueryOptions;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.file.Files;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -99,7 +95,7 @@ public class LPBungeePlugin extends AbstractLuckPermsPlugin {
 
     @Override
     protected ConfigurationAdapter provideConfigurationAdapter() {
-        return new BungeeConfigAdapter(this, resolveConfig());
+        return new BungeeConfigAdapter(this, resolveConfig("config.yml").toFile());
     }
 
     @Override
@@ -173,21 +169,6 @@ public class LPBungeePlugin extends AbstractLuckPermsPlugin {
     @Override
     protected void performFinalSetup() {
 
-    }
-
-    private File resolveConfig() {
-        File configFile = new File(this.bootstrap.getDataFolder(), "config.yml");
-
-        if (!configFile.exists()) {
-            this.bootstrap.getDataFolder().mkdirs();
-            try (InputStream is = this.bootstrap.getResourceAsStream("config.yml")) {
-                Files.copy(is, configFile.toPath());
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-        }
-
-        return configFile;
     }
 
     @Override

--- a/bungee/src/main/java/me/lucko/luckperms/bungee/LPBungeePlugin.java
+++ b/bungee/src/main/java/me/lucko/luckperms/bungee/LPBungeePlugin.java
@@ -51,6 +51,7 @@ import me.lucko.luckperms.common.tasks.ExpireTemporaryTask;
 
 import net.luckperms.api.LuckPerms;
 import net.luckperms.api.query.QueryOptions;
+import net.md_5.bungee.api.plugin.Plugin;
 
 import java.util.Optional;
 import java.util.Set;
@@ -80,6 +81,10 @@ public class LPBungeePlugin extends AbstractLuckPermsPlugin {
         return this.bootstrap;
     }
 
+    public Plugin getLoader() {
+        return this.bootstrap.getLoader();
+    }
+
     @Override
     protected void setupSenderFactory() {
         this.senderFactory = new BungeeSenderFactory(this);
@@ -101,8 +106,8 @@ public class LPBungeePlugin extends AbstractLuckPermsPlugin {
     @Override
     protected void registerPlatformListeners() {
         this.connectionListener = new BungeeConnectionListener(this);
-        this.bootstrap.getProxy().getPluginManager().registerListener(this.bootstrap, this.connectionListener);
-        this.bootstrap.getProxy().getPluginManager().registerListener(this.bootstrap, new BungeePermissionCheckListener(this));
+        this.bootstrap.getProxy().getPluginManager().registerListener(this.bootstrap.getLoader(), this.connectionListener);
+        this.bootstrap.getProxy().getPluginManager().registerListener(this.bootstrap.getLoader(), new BungeePermissionCheckListener(this));
     }
 
     @Override
@@ -137,7 +142,7 @@ public class LPBungeePlugin extends AbstractLuckPermsPlugin {
         this.contextManager = new BungeeContextManager(this);
 
         BungeePlayerCalculator playerCalculator = new BungeePlayerCalculator(this);
-        this.bootstrap.getProxy().getPluginManager().registerListener(this.bootstrap, playerCalculator);
+        this.bootstrap.getProxy().getPluginManager().registerListener(this.bootstrap.getLoader(), playerCalculator);
         this.contextManager.registerCalculator(playerCalculator);
 
         if (this.bootstrap.getProxy().getPluginManager().getPlugin("RedisBungee") != null) {

--- a/bungee/src/main/java/me/lucko/luckperms/bungee/listeners/BungeeConnectionListener.java
+++ b/bungee/src/main/java/me/lucko/luckperms/bungee/listeners/BungeeConnectionListener.java
@@ -76,7 +76,7 @@ public class BungeeConnectionListener extends AbstractConnectionListener impleme
 
         /* registers the plugins intent to modify this events state going forward.
            this will prevent the event from completing until we're finished handling. */
-        e.registerIntent(this.plugin.getBootstrap());
+        e.registerIntent(this.plugin.getLoader());
 
         this.plugin.getBootstrap().getScheduler().executeAsync(() -> {
             /* Actually process the login for the connection.
@@ -106,7 +106,7 @@ public class BungeeConnectionListener extends AbstractConnectionListener impleme
             }
 
             // finally, complete our intent to modify state, so the proxy can continue handling the connection.
-            e.completeIntent(this.plugin.getBootstrap());
+            e.completeIntent(this.plugin.getLoader());
         });
     }
 
@@ -134,7 +134,7 @@ public class BungeeConnectionListener extends AbstractConnectionListener impleme
                 e.getPlayer().disconnect(BungeeComponentSerializer.get().serialize(reason));
             } else {
                 // just send a message
-                this.plugin.getBootstrap().getProxy().getScheduler().schedule(this.plugin.getBootstrap(), () -> {
+                this.plugin.getBootstrap().getProxy().getScheduler().schedule(this.plugin.getLoader(), () -> {
                     if (!player.isConnected()) {
                         return;
                     }

--- a/bungee/src/main/java/me/lucko/luckperms/bungee/messaging/PluginMessageMessenger.java
+++ b/bungee/src/main/java/me/lucko/luckperms/bungee/messaging/PluginMessageMessenger.java
@@ -59,7 +59,7 @@ public class PluginMessageMessenger implements Messenger, Listener {
 
     public void init() {
         ProxyServer proxy = this.plugin.getBootstrap().getProxy();
-        proxy.getPluginManager().registerListener(this.plugin.getBootstrap(), this);
+        proxy.getPluginManager().registerListener(this.plugin.getLoader(), this);
         proxy.registerChannel(CHANNEL);
     }
 

--- a/bungee/src/main/java/me/lucko/luckperms/bungee/messaging/RedisBungeeMessenger.java
+++ b/bungee/src/main/java/me/lucko/luckperms/bungee/messaging/RedisBungeeMessenger.java
@@ -58,7 +58,7 @@ public class RedisBungeeMessenger implements Messenger, Listener {
         this.redisBungee = RedisBungee.getApi();
         this.redisBungee.registerPubSubChannels(CHANNEL);
 
-        this.plugin.getBootstrap().getProxy().getPluginManager().registerListener(this.plugin.getBootstrap(), this);
+        this.plugin.getBootstrap().getProxy().getPluginManager().registerListener(this.plugin.getLoader(), this);
     }
 
     @Override

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -11,6 +11,8 @@ dependencies {
     compile project(':api')
     compile 'org.checkerframework:checker-qual:3.8.0'
 
+    compileOnly project(':common:loader-utils')
+
     compileOnly 'org.slf4j:slf4j-api:1.7.30'
     compileOnly 'org.apache.logging.log4j:log4j-api:2.14.0'
 

--- a/common/loader-utils/build.gradle
+++ b/common/loader-utils/build.gradle
@@ -1,0 +1,1 @@
+// nothing special to do here (yet)!

--- a/common/loader-utils/src/main/java/me/lucko/luckperms/common/loader/JarInJarClassLoader.java
+++ b/common/loader-utils/src/main/java/me/lucko/luckperms/common/loader/JarInJarClassLoader.java
@@ -1,0 +1,139 @@
+/*
+ * This file is part of LuckPerms, licensed under the MIT License.
+ *
+ *  Copyright (c) lucko (Luck) <luck@lucko.me>
+ *  Copyright (c) contributors
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ */
+
+package me.lucko.luckperms.common.loader;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Constructor;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+
+/**
+ * Classloader that can load a jar from within another jar file.
+ *
+ * <p>The "loader" jar contains the loading code & public API classes,
+ * and is class-loaded by the platform.</p>
+ *
+ * <p>The inner "plugin" jar contains the plugin itself, and is class-loaded
+ * by the loading code & this classloader.</p>
+ */
+public class JarInJarClassLoader extends URLClassLoader {
+    static {
+        ClassLoader.registerAsParallelCapable();
+    }
+
+    /**
+     * Creates a new jar-in-jar class loader.
+     *
+     * @param loaderClassLoader the loader plugin's classloader (setup and created by the platform)
+     * @param jarResourcePath the path to the jar-in-jar resource within the loader jar
+     * @throws LoadingException if something unexpectedly bad happens
+     */
+    public JarInJarClassLoader(ClassLoader loaderClassLoader, String jarResourcePath) throws LoadingException {
+        super(new URL[]{extractJar(loaderClassLoader, jarResourcePath)}, loaderClassLoader);
+    }
+
+    public void addJarToClasspath(URL url) {
+        addURL(url);
+    }
+
+    /**
+     * Creates a new plugin instance.
+     *
+     * @param bootstrapClass the name of the bootstrap plugin class
+     * @param loaderPluginType the type of the loader plugin, the only parameter of the bootstrap
+     *                         plugin constructor
+     * @param loaderPlugin the loader plugin instance
+     * @param <T> the type of the loader plugin
+     * @return the instantiated bootstrap plugin
+     */
+    public <T> LoaderBootstrap instantiatePlugin(String bootstrapClass, Class<T> loaderPluginType, T loaderPlugin) throws LoadingException {
+        Class<? extends LoaderBootstrap> plugin;
+        try {
+            plugin = loadClass(bootstrapClass).asSubclass(LoaderBootstrap.class);
+        } catch (ReflectiveOperationException e) {
+            throw new LoadingException("Unable to load bootstrap class", e);
+        }
+
+        Constructor<? extends LoaderBootstrap> constructor;
+        try {
+            constructor = plugin.getConstructor(loaderPluginType);
+        } catch (ReflectiveOperationException e) {
+            throw new LoadingException("Unable to get bootstrap constructor", e);
+        }
+
+        try {
+            return constructor.newInstance(loaderPlugin);
+        } catch (ReflectiveOperationException e) {
+            throw new LoadingException("Unable to create bootstrap plugin instance", e);
+        }
+    }
+
+    /**
+     * Extracts the "jar-in-jar" from the loader plugin into a temporary file,
+     * then returns a URL that can be used by the {@link JarInJarClassLoader}.
+     *
+     * @param loaderClassLoader the classloader for the "host" loader plugin
+     * @param jarResourcePath the inner jar resource path
+     * @return a URL to the extracted file
+     */
+    private static URL extractJar(ClassLoader loaderClassLoader, String jarResourcePath) throws LoadingException {
+        // get the jar-in-jar resource
+        URL jarInJar = loaderClassLoader.getResource(jarResourcePath);
+        if (jarInJar == null) {
+            throw new LoadingException("Could not locate jar-in-jar");
+        }
+
+        // get a temporary file
+        Path path;
+        try {
+            path = Files.createTempFile("luckpermsplugin", "jar");
+        } catch (IOException e) {
+            throw new LoadingException("Unable to create a temporary file", e);
+        }
+
+        // mark that the file should be deleted on exit
+        path.toFile().deleteOnExit();
+
+        // copy the jar-in-jar to the temporary file path
+        try (InputStream in = jarInJar.openStream()) {
+            Files.copy(in, path, StandardCopyOption.REPLACE_EXISTING);
+        } catch (IOException e) {
+            throw new LoadingException("Unable to copy jar-in-jar to temporary path", e);
+        }
+
+        try {
+            return path.toUri().toURL();
+        } catch (MalformedURLException e) {
+            throw new LoadingException("Unable to get URL from path", e);
+        }
+    }
+
+}

--- a/common/loader-utils/src/main/java/me/lucko/luckperms/common/loader/JarInJarClassLoader.java
+++ b/common/loader-utils/src/main/java/me/lucko/luckperms/common/loader/JarInJarClassLoader.java
@@ -111,10 +111,11 @@ public class JarInJarClassLoader extends URLClassLoader {
             throw new LoadingException("Could not locate jar-in-jar");
         }
 
-        // get a temporary file
+        // create a temporary file
+        // on posix systems by default this is only read/writable by the process owner
         Path path;
         try {
-            path = Files.createTempFile("luckpermsplugin", "jar");
+            path = Files.createTempFile("luckperms-jarinjar", ".jar.tmp");
         } catch (IOException e) {
             throw new LoadingException("Unable to create a temporary file", e);
         }

--- a/common/loader-utils/src/main/java/me/lucko/luckperms/common/loader/LoaderBootstrap.java
+++ b/common/loader-utils/src/main/java/me/lucko/luckperms/common/loader/LoaderBootstrap.java
@@ -23,23 +23,17 @@
  *  SOFTWARE.
  */
 
-package me.lucko.luckperms.bukkit;
+package me.lucko.luckperms.common.loader;
 
-import me.lucko.luckperms.common.plugin.scheduler.AbstractJavaScheduler;
-import me.lucko.luckperms.common.plugin.scheduler.SchedulerAdapter;
+/**
+ * Minimal bootstrap plugin, called by the loader plugin.
+ */
+public interface LoaderBootstrap {
 
-import java.util.concurrent.Executor;
+    void onLoad();
 
-public class BukkitSchedulerAdapter extends AbstractJavaScheduler implements SchedulerAdapter {
-    private final Executor sync;
+    void onEnable();
 
-    public BukkitSchedulerAdapter(LPBukkitBootstrap bootstrap) {
-        this.sync = r -> bootstrap.getServer().getScheduler().scheduleSyncDelayedTask(bootstrap.getLoader(), r);
-    }
-
-    @Override
-    public Executor sync() {
-        return this.sync;
-    }
+    void onDisable();
 
 }

--- a/common/loader-utils/src/main/java/me/lucko/luckperms/common/loader/LoadingException.java
+++ b/common/loader-utils/src/main/java/me/lucko/luckperms/common/loader/LoadingException.java
@@ -23,21 +23,19 @@
  *  SOFTWARE.
  */
 
-package me.lucko.luckperms.velocity;
+package me.lucko.luckperms.common.loader;
 
-import me.lucko.luckperms.common.dependencies.classloader.PluginClassLoader;
+/**
+ * Runtime exception used if there is a problem during loading
+ */
+public class LoadingException extends RuntimeException {
 
-import java.nio.file.Path;
-
-public class VelocityClassLoader implements PluginClassLoader {
-    private final LPVelocityBootstrap bootstrap;
-
-    public VelocityClassLoader(LPVelocityBootstrap bootstrap) {
-        this.bootstrap = bootstrap;
+    public LoadingException(String message) {
+        super(message);
     }
 
-    @Override
-    public void addJarToClasspath(Path file) {
-        this.bootstrap.getProxy().getPluginManager().addToClasspath(this.bootstrap, file);
+    public LoadingException(String message, Throwable cause) {
+        super(message, cause);
     }
+
 }

--- a/common/src/main/java/me/lucko/luckperms/common/dependencies/DependencyManager.java
+++ b/common/src/main/java/me/lucko/luckperms/common/dependencies/DependencyManager.java
@@ -150,7 +150,7 @@ public class DependencyManager {
         this.loaded.put(dependency, file);
 
         if (this.registry.shouldAutoLoad(dependency)) {
-            this.plugin.getBootstrap().getPluginClassLoader().addJarToClasspath(file);
+            this.plugin.getBootstrap().getClassPathAppender().addJarToClasspath(file);
         }
     }
 

--- a/common/src/main/java/me/lucko/luckperms/common/extension/SimpleExtensionManager.java
+++ b/common/src/main/java/me/lucko/luckperms/common/extension/SimpleExtensionManager.java
@@ -136,7 +136,7 @@ public class SimpleExtensionManager implements ExtensionManager, AutoCloseable {
             throw new IllegalArgumentException("class is null");
         }
 
-        this.plugin.getBootstrap().getPluginClassLoader().addJarToClasspath(path);
+        this.plugin.getBootstrap().getClassPathAppender().addJarToClasspath(path);
 
         Class<? extends Extension> extensionClass;
         try {

--- a/common/src/main/java/me/lucko/luckperms/common/plugin/AbstractLuckPermsPlugin.java
+++ b/common/src/main/java/me/lucko/luckperms/common/plugin/AbstractLuckPermsPlugin.java
@@ -60,6 +60,10 @@ import net.luckperms.api.LuckPerms;
 
 import okhttp3.OkHttpClient;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -263,6 +267,24 @@ public abstract class AbstractLuckPermsPlugin implements LuckPermsPlugin {
                 Dependency.BYTEBUDDY,
                 Dependency.EVENT
         );
+    }
+
+    protected Path resolveConfig(String fileName) {
+        Path configFile = getBootstrap().getDataDirectory().resolve(fileName);
+        if (!Files.exists(configFile)) {
+            try {
+                Files.createDirectories(configFile.getParent());
+            } catch (IOException e) {
+                // ignore
+            }
+
+            try (InputStream is = getBootstrap().getResourceStream(fileName)) {
+                Files.copy(is, configFile);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return configFile;
     }
 
     protected abstract void setupSenderFactory();

--- a/common/src/main/java/me/lucko/luckperms/common/plugin/bootstrap/LuckPermsBootstrap.java
+++ b/common/src/main/java/me/lucko/luckperms/common/plugin/bootstrap/LuckPermsBootstrap.java
@@ -25,7 +25,7 @@
 
 package me.lucko.luckperms.common.plugin.bootstrap;
 
-import me.lucko.luckperms.common.dependencies.classloader.PluginClassLoader;
+import me.lucko.luckperms.common.plugin.classpath.ClassPathAppender;
 import me.lucko.luckperms.common.plugin.logging.PluginLogger;
 import me.lucko.luckperms.common.plugin.scheduler.SchedulerAdapter;
 
@@ -66,11 +66,11 @@ public interface LuckPermsBootstrap {
     SchedulerAdapter getScheduler();
 
     /**
-     * Gets a {@link PluginClassLoader} for this instance
+     * Gets a {@link ClassPathAppender} for this bootstrap plugin
      *
-     * @return a classloader
+     * @return a class path appender
      */
-    PluginClassLoader getPluginClassLoader();
+    ClassPathAppender getClassPathAppender();
 
     /**
      * Returns a countdown latch which {@link CountDownLatch#countDown() counts down}
@@ -159,7 +159,9 @@ public interface LuckPermsBootstrap {
      * @param path the path of the file
      * @return the file as an input stream
      */
-    InputStream getResourceStream(String path);
+    default InputStream getResourceStream(String path) {
+        return getClass().getClassLoader().getResourceAsStream(path);
+    }
 
     /**
      * Gets a player object linked to this User. The returned object must be the same type

--- a/common/src/main/java/me/lucko/luckperms/common/plugin/classpath/ClassPathAppender.java
+++ b/common/src/main/java/me/lucko/luckperms/common/plugin/classpath/ClassPathAppender.java
@@ -23,27 +23,15 @@
  *  SOFTWARE.
  */
 
-package me.lucko.luckperms.fabric;
+package me.lucko.luckperms.common.plugin.classpath;
 
-import me.lucko.luckperms.common.dependencies.classloader.PluginClassLoader;
-
-import net.fabricmc.loader.launch.common.FabricLauncherBase;
-
-import java.net.MalformedURLException;
 import java.nio.file.Path;
 
-public class FabricClassLoader implements PluginClassLoader {
+/**
+ * Interface which allows access to add URLs to the plugin classpath at runtime.
+ */
+public interface ClassPathAppender {
 
-    @Override
-    public void addJarToClasspath(Path file) {
-        try {
-            // Fabric abstracts class loading away to the FabricLauncher.
-            // TODO(i509VCB): Work on API for Fabric Loader which does not touch internals.
-            //  Player wants to use project jigsaw in the future.
-            FabricLauncherBase.getLauncher().propose(file.toUri().toURL());
-        } catch (MalformedURLException e) {
-            throw new RuntimeException(e);
-        }
-    }
+    void addJarToClasspath(Path file);
 
 }

--- a/common/src/main/java/me/lucko/luckperms/common/plugin/classpath/JarInJarClassPathAppender.java
+++ b/common/src/main/java/me/lucko/luckperms/common/plugin/classpath/JarInJarClassPathAppender.java
@@ -23,23 +23,29 @@
  *  SOFTWARE.
  */
 
-package me.lucko.luckperms.bukkit;
+package me.lucko.luckperms.common.plugin.classpath;
 
-import me.lucko.luckperms.common.plugin.scheduler.AbstractJavaScheduler;
-import me.lucko.luckperms.common.plugin.scheduler.SchedulerAdapter;
+import me.lucko.luckperms.common.loader.JarInJarClassLoader;
 
-import java.util.concurrent.Executor;
+import java.net.MalformedURLException;
+import java.nio.file.Path;
 
-public class BukkitSchedulerAdapter extends AbstractJavaScheduler implements SchedulerAdapter {
-    private final Executor sync;
+public class JarInJarClassPathAppender implements ClassPathAppender {
+    private final JarInJarClassLoader classLoader;
 
-    public BukkitSchedulerAdapter(LPBukkitBootstrap bootstrap) {
-        this.sync = r -> bootstrap.getServer().getScheduler().scheduleSyncDelayedTask(bootstrap.getLoader(), r);
+    public JarInJarClassPathAppender(ClassLoader classLoader) {
+        if (!(classLoader instanceof JarInJarClassLoader)) {
+            throw new IllegalArgumentException("Loader is not a JarInJarClassLoader: " + classLoader.getClass().getName());
+        }
+        this.classLoader = (JarInJarClassLoader) classLoader;
     }
 
     @Override
-    public Executor sync() {
-        return this.sync;
+    public void addJarToClasspath(Path file) {
+        try {
+            this.classLoader.addJarToClasspath(file.toUri().toURL());
+        } catch (MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
     }
-
 }

--- a/common/src/main/java/me/lucko/luckperms/common/plugin/classpath/ReflectionClassPathAppender.java
+++ b/common/src/main/java/me/lucko/luckperms/common/plugin/classpath/ReflectionClassPathAppender.java
@@ -23,19 +23,18 @@
  *  SOFTWARE.
  */
 
-package me.lucko.luckperms.common.dependencies.classloader;
+package me.lucko.luckperms.common.plugin.classpath;
 
 import me.lucko.luckperms.common.plugin.bootstrap.LuckPermsBootstrap;
 
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Path;
 
-public class ReflectionClassLoader implements PluginClassLoader {
-
+@Deprecated // TODO: no longer works on Java 16 - Bungee, Nukkit & Sponge need to switch to JarInJar
+public class ReflectionClassPathAppender implements ClassPathAppender {
     private static final Method ADD_URL_METHOD;
 
     static {
@@ -58,7 +57,7 @@ public class ReflectionClassLoader implements PluginClassLoader {
 
     private final URLClassLoader classLoader;
 
-    public ReflectionClassLoader(LuckPermsBootstrap bootstrap) throws IllegalStateException {
+    public ReflectionClassPathAppender(LuckPermsBootstrap bootstrap) throws IllegalStateException {
         ClassLoader classLoader = bootstrap.getClass().getClassLoader();
         if (classLoader instanceof URLClassLoader) {
             this.classLoader = (URLClassLoader) classLoader;
@@ -71,7 +70,7 @@ public class ReflectionClassLoader implements PluginClassLoader {
     public void addJarToClasspath(Path file) {
         try {
             ADD_URL_METHOD.invoke(this.classLoader, file.toUri().toURL());
-        } catch (IllegalAccessException | InvocationTargetException | MalformedURLException e) {
+        } catch (ReflectiveOperationException | MalformedURLException e) {
             throw new RuntimeException(e);
         }
     }
@@ -92,7 +91,7 @@ public class ReflectionClassLoader implements PluginClassLoader {
         Method addOpensMethod = moduleClass.getMethod("addOpens", String.class, moduleClass);
 
         Object urlClassLoaderModule = getModuleMethod.invoke(URLClassLoader.class);
-        Object thisModule = getModuleMethod.invoke(ReflectionClassLoader.class);
+        Object thisModule = getModuleMethod.invoke(ReflectionClassPathAppender.class);
 
         addOpensMethod.invoke(urlClassLoaderModule, URLClassLoader.class.getPackage().getName(), thisModule);
     }

--- a/common/src/main/java/me/lucko/luckperms/common/plugin/classpath/ReflectionClassPathAppender.java
+++ b/common/src/main/java/me/lucko/luckperms/common/plugin/classpath/ReflectionClassPathAppender.java
@@ -33,7 +33,7 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Path;
 
-@Deprecated // TODO: no longer works on Java 16 - Bungee, Nukkit & Sponge need to switch to JarInJar
+@Deprecated // TODO: no longer works on Java 16 - Sponge needs to switch to JarInJar or find an API to add to classpath at runtime
 public class ReflectionClassPathAppender implements ClassPathAppender {
     private static final Method ADD_URL_METHOD;
 

--- a/fabric/src/main/java/me/lucko/luckperms/fabric/FabricClassPathAppender.java
+++ b/fabric/src/main/java/me/lucko/luckperms/fabric/FabricClassPathAppender.java
@@ -23,23 +23,27 @@
  *  SOFTWARE.
  */
 
-package me.lucko.luckperms.bukkit;
+package me.lucko.luckperms.fabric;
 
-import me.lucko.luckperms.common.plugin.scheduler.AbstractJavaScheduler;
-import me.lucko.luckperms.common.plugin.scheduler.SchedulerAdapter;
+import me.lucko.luckperms.common.plugin.classpath.ClassPathAppender;
 
-import java.util.concurrent.Executor;
+import net.fabricmc.loader.launch.common.FabricLauncherBase;
 
-public class BukkitSchedulerAdapter extends AbstractJavaScheduler implements SchedulerAdapter {
-    private final Executor sync;
+import java.net.MalformedURLException;
+import java.nio.file.Path;
 
-    public BukkitSchedulerAdapter(LPBukkitBootstrap bootstrap) {
-        this.sync = r -> bootstrap.getServer().getScheduler().scheduleSyncDelayedTask(bootstrap.getLoader(), r);
-    }
+public class FabricClassPathAppender implements ClassPathAppender {
 
     @Override
-    public Executor sync() {
-        return this.sync;
+    public void addJarToClasspath(Path file) {
+        try {
+            // Fabric abstracts class loading away to the FabricLauncher.
+            // TODO(i509VCB): Work on API for Fabric Loader which does not touch internals.
+            //  Player wants to use project jigsaw in the future.
+            FabricLauncherBase.getLauncher().propose(file.toUri().toURL());
+        } catch (MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
     }
 
 }

--- a/fabric/src/main/java/me/lucko/luckperms/fabric/LPFabricBootstrap.java
+++ b/fabric/src/main/java/me/lucko/luckperms/fabric/LPFabricBootstrap.java
@@ -27,8 +27,8 @@ package me.lucko.luckperms.fabric;
 
 import com.mojang.authlib.GameProfile;
 
-import me.lucko.luckperms.common.dependencies.classloader.PluginClassLoader;
 import me.lucko.luckperms.common.plugin.bootstrap.LuckPermsBootstrap;
+import me.lucko.luckperms.common.plugin.classpath.ClassPathAppender;
 import me.lucko.luckperms.common.plugin.logging.Log4jPluginLogger;
 import me.lucko.luckperms.common.plugin.logging.PluginLogger;
 import me.lucko.luckperms.common.plugin.scheduler.SchedulerAdapter;
@@ -76,9 +76,9 @@ public final class LPFabricBootstrap implements LuckPermsBootstrap, DedicatedSer
     private final SchedulerAdapter schedulerAdapter;
 
     /**
-     * The plugin class loader.
+     * The plugin class path appender
      */
-    private final PluginClassLoader classLoader;
+    private final ClassPathAppender classPathAppender;
 
     /**
      * The plugin instance
@@ -102,7 +102,7 @@ public final class LPFabricBootstrap implements LuckPermsBootstrap, DedicatedSer
     public LPFabricBootstrap() {
         this.logger = new Log4jPluginLogger(LogManager.getLogger(MODID));
         this.schedulerAdapter = new FabricSchedulerAdapter(this);
-        this.classLoader = new FabricClassLoader();
+        this.classPathAppender = new FabricClassPathAppender();
         this.plugin = new LPFabricPlugin(this);
     }
     
@@ -119,8 +119,8 @@ public final class LPFabricBootstrap implements LuckPermsBootstrap, DedicatedSer
     }
 
     @Override
-    public PluginClassLoader getPluginClassLoader() {
-        return this.classLoader;
+    public ClassPathAppender getClassPathAppender() {
+        return this.classPathAppender;
     }
     
     // lifecycle

--- a/fabric/src/main/java/me/lucko/luckperms/fabric/LPFabricPlugin.java
+++ b/fabric/src/main/java/me/lucko/luckperms/fabric/LPFabricPlugin.java
@@ -41,7 +41,6 @@ import me.lucko.luckperms.common.sender.DummySender;
 import me.lucko.luckperms.common.sender.Sender;
 import me.lucko.luckperms.common.tasks.CacheHousekeepingTask;
 import me.lucko.luckperms.common.tasks.ExpireTemporaryTask;
-import me.lucko.luckperms.common.util.MoreFiles;
 import me.lucko.luckperms.fabric.context.FabricContextManager;
 import me.lucko.luckperms.fabric.context.FabricPlayerCalculator;
 import me.lucko.luckperms.fabric.listeners.FabricConnectionListener;
@@ -55,10 +54,6 @@ import net.luckperms.api.LuckPerms;
 import net.luckperms.api.query.QueryOptions;
 import net.minecraft.server.MinecraftServer;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -112,20 +107,7 @@ public class LPFabricPlugin extends AbstractLuckPermsPlugin {
 
     @Override
     protected ConfigurationAdapter provideConfigurationAdapter() {
-        Path configPath = this.getBootstrap().getConfigDirectory().resolve("luckperms.conf");
-
-        if (!Files.exists(configPath)) {
-            try {
-                MoreFiles.createDirectoriesIfNotExists(this.bootstrap.getConfigDirectory());
-                try (InputStream is = this.getBootstrap().getResourceStream("luckperms.conf")) {
-                    Files.copy(is, configPath);
-                }
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-        }
-
-        return new FabricConfigAdapter(this, configPath);
+        return new FabricConfigAdapter(this, resolveConfig("luckperms.conf"));
     }
 
     @Override

--- a/nukkit/build.gradle
+++ b/nukkit/build.gradle
@@ -9,22 +9,15 @@ repositories {
 
 dependencies {
     compile project(':common')
+    compileOnly project(':common:loader-utils')
 
     compileOnly 'cn.nukkit:nukkit:1.0-SNAPSHOT'
 }
 
-processResources {
-    from(sourceSets.main.resources.srcDirs) {
-        expand 'pluginVersion': project.ext.fullVersion
-        include 'plugin.yml'
-    }
-}
-
 shadowJar {
-    archiveName = "LuckPerms-Nukkit-${project.ext.fullVersion}.jar"
+    archiveName = 'luckperms-nukkit.jarinjar'
 
     dependencies {
-        include(dependency('net.luckperms:.*'))
         include(dependency('me.lucko.luckperms:.*'))
     }
 

--- a/nukkit/loader/build.gradle
+++ b/nukkit/loader/build.gradle
@@ -1,0 +1,34 @@
+plugins {
+    id 'com.github.johnrengelman.shadow'
+}
+
+repositories {
+    mavenLocal()
+    maven { url 'https://repo.nukkitx.com/main/' }
+}
+
+dependencies {
+    compileOnly 'cn.nukkit:nukkit:1.0-SNAPSHOT'
+
+    compile project(':api')
+    compile project(':common:loader-utils')
+}
+
+processResources {
+    from(sourceSets.main.resources.srcDirs) {
+        expand 'pluginVersion': project.ext.fullVersion
+        include 'plugin.yml'
+    }
+}
+
+shadowJar {
+    archiveName = "LuckPerms-Nukkit-${project.ext.fullVersion}.jar"
+
+    from {
+        project(':nukkit').tasks.shadowJar.archiveFile
+    }
+}
+
+artifacts {
+    archives shadowJar
+}

--- a/nukkit/loader/src/main/java/me/lucko/luckperms/nukkit/loader/NukkitLoaderPlugin.java
+++ b/nukkit/loader/src/main/java/me/lucko/luckperms/nukkit/loader/NukkitLoaderPlugin.java
@@ -23,22 +23,22 @@
  *  SOFTWARE.
  */
 
-package me.lucko.luckperms.bukkit.loader;
+package me.lucko.luckperms.nukkit.loader;
 
 import me.lucko.luckperms.common.loader.JarInJarClassLoader;
 import me.lucko.luckperms.common.loader.LoaderBootstrap;
 
-import org.bukkit.plugin.java.JavaPlugin;
+import cn.nukkit.plugin.PluginBase;
 
-public class BukkitLoaderPlugin extends JavaPlugin {
-    private static final String JAR_NAME = "luckperms-bukkit.jarinjar";
-    private static final String BOOTSTRAP_CLASS = "me.lucko.luckperms.bukkit.LPBukkitBootstrap";
+public class NukkitLoaderPlugin extends PluginBase {
+    private static final String JAR_NAME = "luckperms-nukkit.jarinjar";
+    private static final String BOOTSTRAP_CLASS = "me.lucko.luckperms.nukkit.LPNukkitBootstrap";
 
     private final LoaderBootstrap plugin;
 
-    public BukkitLoaderPlugin() {
+    public NukkitLoaderPlugin() {
         JarInJarClassLoader loader = new JarInJarClassLoader(getClass().getClassLoader(), JAR_NAME);
-        this.plugin = loader.instantiatePlugin(BOOTSTRAP_CLASS, JavaPlugin.class, this);
+        this.plugin = loader.instantiatePlugin(BOOTSTRAP_CLASS, PluginBase.class, this);
     }
 
     @Override

--- a/nukkit/loader/src/main/resources/plugin.yml
+++ b/nukkit/loader/src/main/resources/plugin.yml
@@ -5,7 +5,7 @@ description: A permissions plugin
 author: Luck
 website: https://luckperms.net
 
-main: me.lucko.luckperms.nukkit.LPNukkitBootstrap
+main: me.lucko.luckperms.nukkit.loader.NukkitLoaderPlugin
 load: STARTUP
 
 commands:

--- a/nukkit/src/main/java/me/lucko/luckperms/nukkit/LPNukkitBootstrap.java
+++ b/nukkit/src/main/java/me/lucko/luckperms/nukkit/LPNukkitBootstrap.java
@@ -25,9 +25,9 @@
 
 package me.lucko.luckperms.nukkit;
 
-import me.lucko.luckperms.common.dependencies.classloader.PluginClassLoader;
-import me.lucko.luckperms.common.dependencies.classloader.ReflectionClassLoader;
 import me.lucko.luckperms.common.plugin.bootstrap.LuckPermsBootstrap;
+import me.lucko.luckperms.common.plugin.classpath.ClassPathAppender;
+import me.lucko.luckperms.common.plugin.classpath.ReflectionClassPathAppender;
 import me.lucko.luckperms.common.plugin.logging.PluginLogger;
 
 import net.luckperms.api.platform.Platform;
@@ -35,7 +35,6 @@ import net.luckperms.api.platform.Platform;
 import cn.nukkit.Player;
 import cn.nukkit.plugin.PluginBase;
 
-import java.io.InputStream;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -61,9 +60,9 @@ public class LPNukkitBootstrap extends PluginBase implements LuckPermsBootstrap 
     private final NukkitSchedulerAdapter schedulerAdapter;
 
     /**
-     * The plugin classloader
+     * The plugin class path appender
      */
-    private final PluginClassLoader classLoader;
+    private final ClassPathAppender classPathAppender;
 
     /**
      * The plugin instance
@@ -81,7 +80,7 @@ public class LPNukkitBootstrap extends PluginBase implements LuckPermsBootstrap 
 
     public LPNukkitBootstrap() {
         this.schedulerAdapter = new NukkitSchedulerAdapter(this);
-        this.classLoader = new ReflectionClassLoader(this);
+        this.classPathAppender = new ReflectionClassPathAppender(this);
         this.plugin = new LPNukkitPlugin(this);
     }
 
@@ -101,8 +100,8 @@ public class LPNukkitBootstrap extends PluginBase implements LuckPermsBootstrap 
     }
 
     @Override
-    public PluginClassLoader getPluginClassLoader() {
-        return this.classLoader;
+    public ClassPathAppender getClassPathAppender() {
+        return this.classPathAppender;
     }
 
     // lifecycle
@@ -175,11 +174,6 @@ public class LPNukkitBootstrap extends PluginBase implements LuckPermsBootstrap 
     @Override
     public Path getDataDirectory() {
         return getDataFolder().toPath().toAbsolutePath();
-    }
-
-    @Override
-    public InputStream getResourceStream(String path) {
-        return getResource(path);
     }
 
     @Override

--- a/nukkit/src/main/java/me/lucko/luckperms/nukkit/LPNukkitPlugin.java
+++ b/nukkit/src/main/java/me/lucko/luckperms/nukkit/LPNukkitPlugin.java
@@ -68,8 +68,6 @@ import cn.nukkit.plugin.PluginManager;
 import cn.nukkit.plugin.service.ServicePriority;
 import cn.nukkit.utils.Config;
 
-import java.io.File;
-import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
@@ -107,7 +105,7 @@ public class LPNukkitPlugin extends AbstractLuckPermsPlugin {
 
     @Override
     protected ConfigurationAdapter provideConfigurationAdapter() {
-        return new NukkitConfigAdapter(this, resolveConfig());
+        return new NukkitConfigAdapter(this, resolveConfig("config.yml").toFile());
     }
 
     @Override
@@ -260,33 +258,6 @@ public class LPNukkitPlugin extends AbstractLuckPermsPlugin {
         InjectorPermissionMap.uninject();
         InjectorDefaultsMap.uninject();
         new PermissibleMonitoringInjector(this, PermissibleMonitoringInjector.Mode.UNINJECT).run();
-    }
-
-    public void refreshAutoOp(Player player) {
-        if (!getConfiguration().get(ConfigKeys.AUTO_OP)) {
-            return;
-        }
-
-        User user = getUserManager().getIfLoaded(player.getUniqueId());
-        boolean value;
-
-        if (user != null) {
-            Map<String, Boolean> permData = user.getCachedData().getPermissionData(this.contextManager.getQueryOptions(player)).getPermissionMap();
-            value = permData.getOrDefault("luckperms.autoop", false);
-        } else {
-            value = false;
-        }
-
-        player.setOp(value);
-    }
-
-    private File resolveConfig() {
-        File configFile = new File(this.bootstrap.getDataFolder(), "config.yml");
-        if (!configFile.exists()) {
-            this.bootstrap.getDataFolder().mkdirs();
-            this.bootstrap.saveResource("config.yml", false);
-        }
-        return configFile;
     }
 
     @Override

--- a/nukkit/src/main/java/me/lucko/luckperms/nukkit/LPNukkitPlugin.java
+++ b/nukkit/src/main/java/me/lucko/luckperms/nukkit/LPNukkitPlugin.java
@@ -64,6 +64,7 @@ import net.luckperms.api.query.QueryOptions;
 import cn.nukkit.Player;
 import cn.nukkit.command.PluginCommand;
 import cn.nukkit.permission.Permission;
+import cn.nukkit.plugin.PluginBase;
 import cn.nukkit.plugin.PluginManager;
 import cn.nukkit.plugin.service.ServicePriority;
 import cn.nukkit.utils.Config;
@@ -98,6 +99,10 @@ public class LPNukkitPlugin extends AbstractLuckPermsPlugin {
         return this.bootstrap;
     }
 
+    public PluginBase getLoader() {
+        return this.bootstrap.getLoader();
+    }
+
     @Override
     protected void setupSenderFactory() {
         this.senderFactory = new NukkitSenderFactory(this);
@@ -111,8 +116,8 @@ public class LPNukkitPlugin extends AbstractLuckPermsPlugin {
     @Override
     protected void registerPlatformListeners() {
         this.connectionListener = new NukkitConnectionListener(this);
-        this.bootstrap.getServer().getPluginManager().registerEvents(this.connectionListener, this.bootstrap);
-        this.bootstrap.getServer().getPluginManager().registerEvents(new NukkitPlatformListener(this), this.bootstrap);
+        this.bootstrap.getServer().getPluginManager().registerEvents(this.connectionListener, this.bootstrap.getLoader());
+        this.bootstrap.getServer().getPluginManager().registerEvents(new NukkitPlatformListener(this), this.bootstrap.getLoader());
     }
 
     @Override
@@ -144,7 +149,7 @@ public class LPNukkitPlugin extends AbstractLuckPermsPlugin {
         this.contextManager = new NukkitContextManager(this);
 
         NukkitPlayerCalculator playerCalculator = new NukkitPlayerCalculator(this);
-        this.bootstrap.getServer().getPluginManager().registerEvents(playerCalculator, this.bootstrap);
+        this.bootstrap.getServer().getPluginManager().registerEvents(playerCalculator, this.bootstrap.getLoader());
         this.contextManager.registerCalculator(playerCalculator);
     }
 
@@ -163,7 +168,7 @@ public class LPNukkitPlugin extends AbstractLuckPermsPlugin {
 
             // schedule another injection after all plugins have loaded
             // the entire pluginmanager instance is replaced by some plugins :(
-            this.bootstrap.getServer().getScheduler().scheduleDelayedTask(this.bootstrap, injector, 1, true);
+            this.bootstrap.getServer().getScheduler().scheduleDelayedTask(this.bootstrap.getLoader(), injector, 1, true);
         }
     }
 
@@ -174,7 +179,7 @@ public class LPNukkitPlugin extends AbstractLuckPermsPlugin {
 
     @Override
     protected void registerApiOnPlatform(LuckPerms api) {
-        this.bootstrap.getServer().getServiceManager().register(LuckPerms.class, api, this.bootstrap, ServicePriority.NORMAL);
+        this.bootstrap.getServer().getServiceManager().register(LuckPerms.class, api, this.bootstrap.getLoader(), ServicePriority.NORMAL);
     }
 
     @Override

--- a/nukkit/src/main/java/me/lucko/luckperms/nukkit/NukkitCommandExecutor.java
+++ b/nukkit/src/main/java/me/lucko/luckperms/nukkit/NukkitCommandExecutor.java
@@ -52,7 +52,7 @@ public class NukkitCommandExecutor extends CommandManager implements CommandExec
 
     public void register() {
         this.command.setExecutor(this);
-        this.plugin.getBootstrap().getServer().getPluginManager().registerEvents(this, this.plugin.getBootstrap());
+        this.plugin.getBootstrap().getServer().getPluginManager().registerEvents(this, this.plugin.getLoader());
     }
 
     @Override

--- a/nukkit/src/main/java/me/lucko/luckperms/nukkit/NukkitEventBus.java
+++ b/nukkit/src/main/java/me/lucko/luckperms/nukkit/NukkitEventBus.java
@@ -39,7 +39,7 @@ public class NukkitEventBus extends AbstractEventBus<Plugin> implements Listener
 
         // register listener
         LPNukkitBootstrap bootstrap = plugin.getBootstrap();
-        bootstrap.getServer().getPluginManager().registerEvents(this, bootstrap);
+        bootstrap.getServer().getPluginManager().registerEvents(this, bootstrap.getLoader());
     }
 
     @Override

--- a/nukkit/src/main/java/me/lucko/luckperms/nukkit/NukkitSchedulerAdapter.java
+++ b/nukkit/src/main/java/me/lucko/luckperms/nukkit/NukkitSchedulerAdapter.java
@@ -34,7 +34,7 @@ public class NukkitSchedulerAdapter extends AbstractJavaScheduler implements Sch
     private final Executor sync;
 
     public NukkitSchedulerAdapter(LPNukkitBootstrap bootstrap) {
-        this.sync = r -> bootstrap.getServer().getScheduler().scheduleTask(bootstrap, r, false);
+        this.sync = r -> bootstrap.getServer().getScheduler().scheduleTask(bootstrap.getLoader(), r, false);
     }
 
     @Override

--- a/nukkit/src/main/java/me/lucko/luckperms/nukkit/inject/permissible/LuckPermsPermissionAttachment.java
+++ b/nukkit/src/main/java/me/lucko/luckperms/nukkit/inject/permissible/LuckPermsPermissionAttachment.java
@@ -316,7 +316,7 @@ public class LuckPermsPermissionAttachment extends PermissionAttachment {
 
     @Override
     public Plugin getPlugin() {
-        return this.owner != null ? this.owner : this.permissible.getPlugin().getBootstrap();
+        return this.owner != null ? this.owner : this.permissible.getPlugin().getLoader();
     }
 
     @Override

--- a/nukkit/src/main/java/me/lucko/luckperms/nukkit/listeners/NukkitConnectionListener.java
+++ b/nukkit/src/main/java/me/lucko/luckperms/nukkit/listeners/NukkitConnectionListener.java
@@ -204,7 +204,7 @@ public class NukkitConnectionListener extends AbstractConnectionListener impleme
 
         // perform unhooking from nukkit objects 1 tick later.
         // this allows plugins listening after us on MONITOR to still have intact permissions data
-        this.plugin.getBootstrap().getServer().getScheduler().scheduleDelayedTask(this.plugin.getBootstrap(), () -> {
+        this.plugin.getBootstrap().getServer().getScheduler().scheduleDelayedTask(this.plugin.getLoader(), () -> {
             // Remove the custom permissible
             try {
                 PermissibleInjector.uninject(player, true);

--- a/settings.gradle
+++ b/settings.gradle
@@ -13,7 +13,9 @@ rootProject.name = 'luckperms'
 include (
         'api',
         'common',
+        'common:loader-utils',
         'bukkit',
+        'bukkit:loader',
         'bukkit-legacy',
         'bungee',
         'fabric',

--- a/settings.gradle
+++ b/settings.gradle
@@ -18,8 +18,10 @@ include (
         'bukkit:loader',
         'bukkit-legacy',
         'bungee',
+        'bungee:loader',
         'fabric',
         'nukkit',
+        'nukkit:loader',
         'sponge', 'sponge:sponge-service', 'sponge:sponge-service-api6', 'sponge:sponge-service-api7',
         'velocity'
 )

--- a/sponge/build.gradle
+++ b/sponge/build.gradle
@@ -63,13 +63,3 @@ shadowJar {
 artifacts {
     archives shadowJar
 }
-
-// Only used occasionally for deployment - not needed for normal builds.
-/*
-apply plugin: 'signing'
-
-signing {
-    useGpgCmd()
-    sign configurations.archives
-}
-*/

--- a/sponge/src/main/java/me/lucko/luckperms/sponge/LPSpongeBootstrap.java
+++ b/sponge/src/main/java/me/lucko/luckperms/sponge/LPSpongeBootstrap.java
@@ -27,9 +27,9 @@ package me.lucko.luckperms.sponge;
 
 import com.google.inject.Inject;
 
-import me.lucko.luckperms.common.dependencies.classloader.PluginClassLoader;
-import me.lucko.luckperms.common.dependencies.classloader.ReflectionClassLoader;
 import me.lucko.luckperms.common.plugin.bootstrap.LuckPermsBootstrap;
+import me.lucko.luckperms.common.plugin.classpath.ClassPathAppender;
+import me.lucko.luckperms.common.plugin.classpath.ReflectionClassPathAppender;
 import me.lucko.luckperms.common.plugin.logging.PluginLogger;
 import me.lucko.luckperms.common.plugin.logging.Slf4jPluginLogger;
 import me.lucko.luckperms.common.plugin.scheduler.SchedulerAdapter;
@@ -56,7 +56,6 @@ import org.spongepowered.api.scheduler.SpongeExecutorService;
 import org.spongepowered.api.scheduler.SynchronousExecutor;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -95,9 +94,9 @@ public class LPSpongeBootstrap implements LuckPermsBootstrap {
     private final SchedulerAdapter schedulerAdapter;
 
     /**
-     * The plugin classloader
+     * The plugin class path appender
      */
-    private final PluginClassLoader classLoader;
+    private final ClassPathAppender classPathAppender;
 
     /**
      * The plugin instance
@@ -142,7 +141,7 @@ public class LPSpongeBootstrap implements LuckPermsBootstrap {
         this.logger = new Slf4jPluginLogger(logger);
         this.spongeScheduler = Sponge.getScheduler();
         this.schedulerAdapter = new SpongeSchedulerAdapter(this, this.spongeScheduler, syncExecutor, asyncExecutor);
-        this.classLoader = new ReflectionClassLoader(this);
+        this.classPathAppender = new ReflectionClassPathAppender(this);
         this.plugin = new LPSpongePlugin(this);
     }
 
@@ -159,8 +158,8 @@ public class LPSpongeBootstrap implements LuckPermsBootstrap {
     }
 
     @Override
-    public PluginClassLoader getPluginClassLoader() {
-        return this.classLoader;
+    public ClassPathAppender getClassPathAppender() {
+        return this.classPathAppender;
     }
 
     // lifecycle
@@ -264,11 +263,6 @@ public class LPSpongeBootstrap implements LuckPermsBootstrap {
     @Override
     public Path getConfigDirectory() {
         return this.configDirectory.toAbsolutePath();
-    }
-
-    @Override
-    public InputStream getResourceStream(String path) {
-        return getClass().getClassLoader().getResourceAsStream(path);
     }
 
     @Override

--- a/sponge/src/main/java/me/lucko/luckperms/sponge/LPSpongePlugin.java
+++ b/sponge/src/main/java/me/lucko/luckperms/sponge/LPSpongePlugin.java
@@ -41,7 +41,6 @@ import me.lucko.luckperms.common.sender.DummySender;
 import me.lucko.luckperms.common.sender.Sender;
 import me.lucko.luckperms.common.tasks.CacheHousekeepingTask;
 import me.lucko.luckperms.common.tasks.ExpireTemporaryTask;
-import me.lucko.luckperms.common.util.MoreFiles;
 import me.lucko.luckperms.sponge.calculator.SpongeCalculatorFactory;
 import me.lucko.luckperms.sponge.commands.SpongeParentCommand;
 import me.lucko.luckperms.sponge.context.SpongeContextManager;
@@ -67,10 +66,6 @@ import net.luckperms.api.query.QueryOptions;
 import org.spongepowered.api.service.permission.PermissionDescription;
 import org.spongepowered.api.service.permission.PermissionService;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -123,7 +118,7 @@ public class LPSpongePlugin extends AbstractLuckPermsPlugin {
 
     @Override
     protected ConfigurationAdapter provideConfigurationAdapter() {
-        return new SpongeConfigAdapter(this, resolveConfig());
+        return new SpongeConfigAdapter(this, resolveConfig("luckperms.conf"));
     }
 
     @Override
@@ -236,22 +231,6 @@ public class LPSpongePlugin extends AbstractLuckPermsPlugin {
         this.service.invalidateAllCaches();
     }
 
-    private Path resolveConfig() {
-        Path path = this.bootstrap.getConfigDirectory().resolve("luckperms.conf");
-        if (!Files.exists(path)) {
-            try {
-                MoreFiles.createDirectoriesIfNotExists(this.bootstrap.getConfigDirectory());
-                try (InputStream is = getClass().getClassLoader().getResourceAsStream("luckperms.conf")) {
-                    Files.copy(is, path);
-                }
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-        }
-
-        return path;
-    }
-
     @Override
     public Optional<QueryOptions> getQueryOptionsForUser(User user) {
         return this.bootstrap.getPlayer(user.getUniqueId()).map(player -> this.contextManager.getQueryOptions(player));
@@ -273,7 +252,7 @@ public class LPSpongePlugin extends AbstractLuckPermsPlugin {
             return new DummySender(this, Sender.CONSOLE_UUID, Sender.CONSOLE_NAME) {
                 @Override
                 public void sendMessage(Component message) {
-                    LPSpongePlugin.this.bootstrap.getPluginLogger().info(LegacyComponentSerializer.legacySection().serialize(TranslationManager.render(message)));
+                    LPSpongePlugin.this.getLogger().info(LegacyComponentSerializer.legacySection().serialize(TranslationManager.render(message)));
                 }
             };
         }

--- a/velocity/src/main/java/me/lucko/luckperms/velocity/LPVelocityBootstrap.java
+++ b/velocity/src/main/java/me/lucko/luckperms/velocity/LPVelocityBootstrap.java
@@ -35,8 +35,8 @@ import com.velocitypowered.api.plugin.annotation.DataDirectory;
 import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.ProxyServer;
 
-import me.lucko.luckperms.common.dependencies.classloader.PluginClassLoader;
 import me.lucko.luckperms.common.plugin.bootstrap.LuckPermsBootstrap;
+import me.lucko.luckperms.common.plugin.classpath.ClassPathAppender;
 import me.lucko.luckperms.common.plugin.logging.PluginLogger;
 import me.lucko.luckperms.common.plugin.logging.Slf4jPluginLogger;
 import me.lucko.luckperms.common.plugin.scheduler.SchedulerAdapter;
@@ -45,7 +45,6 @@ import net.luckperms.api.platform.Platform;
 
 import org.slf4j.Logger;
 
-import java.io.InputStream;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -79,9 +78,9 @@ public class LPVelocityBootstrap implements LuckPermsBootstrap {
     private final SchedulerAdapter schedulerAdapter;
 
     /**
-     * The plugin classloader
+     * The plugin class path appender
      */
-    private final PluginClassLoader classLoader;
+    private final ClassPathAppender classPathAppender;
 
     /**
      * The plugin instance
@@ -108,7 +107,7 @@ public class LPVelocityBootstrap implements LuckPermsBootstrap {
     public LPVelocityBootstrap(Logger logger) {
         this.logger = new Slf4jPluginLogger(logger);
         this.schedulerAdapter = new VelocitySchedulerAdapter(this);
-        this.classLoader = new VelocityClassLoader(this);
+        this.classPathAppender = new VelocityClassPathAppender(this);
         this.plugin = new LPVelocityPlugin(this);
     }
 
@@ -125,8 +124,8 @@ public class LPVelocityBootstrap implements LuckPermsBootstrap {
     }
 
     @Override
-    public PluginClassLoader getPluginClassLoader() {
-        return this.classLoader;
+    public ClassPathAppender getClassPathAppender() {
+        return this.classPathAppender;
     }
 
     // lifecycle
@@ -200,11 +199,6 @@ public class LPVelocityBootstrap implements LuckPermsBootstrap {
     @Override
     public Path getDataDirectory() {
         return this.configDirectory.toAbsolutePath();
-    }
-
-    @Override
-    public InputStream getResourceStream(String path) {
-        return getClass().getClassLoader().getResourceAsStream(path);
     }
 
     @Override

--- a/velocity/src/main/java/me/lucko/luckperms/velocity/LPVelocityPlugin.java
+++ b/velocity/src/main/java/me/lucko/luckperms/velocity/LPVelocityPlugin.java
@@ -41,7 +41,6 @@ import me.lucko.luckperms.common.plugin.util.AbstractConnectionListener;
 import me.lucko.luckperms.common.sender.Sender;
 import me.lucko.luckperms.common.tasks.CacheHousekeepingTask;
 import me.lucko.luckperms.common.tasks.ExpireTemporaryTask;
-import me.lucko.luckperms.common.util.MoreFiles;
 import me.lucko.luckperms.velocity.calculator.VelocityCalculatorFactory;
 import me.lucko.luckperms.velocity.context.VelocityContextManager;
 import me.lucko.luckperms.velocity.context.VelocityPlayerCalculator;
@@ -52,10 +51,6 @@ import me.lucko.luckperms.velocity.messaging.VelocityMessagingFactory;
 import net.luckperms.api.LuckPerms;
 import net.luckperms.api.query.QueryOptions;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -101,7 +96,7 @@ public class LPVelocityPlugin extends AbstractLuckPermsPlugin {
 
     @Override
     protected ConfigurationAdapter provideConfigurationAdapter() {
-        return new VelocityConfigAdapter(this, resolveConfig());
+        return new VelocityConfigAdapter(this, resolveConfig("config.yml"));
     }
 
     @Override
@@ -167,22 +162,6 @@ public class LPVelocityPlugin extends AbstractLuckPermsPlugin {
     @Override
     protected void performFinalSetup() {
 
-    }
-
-    private Path resolveConfig() {
-        Path path = this.bootstrap.getConfigDirectory().resolve("config.yml");
-        if (!Files.exists(path)) {
-            try {
-                MoreFiles.createDirectoriesIfNotExists(this.bootstrap.getConfigDirectory());
-                try (InputStream is = getClass().getClassLoader().getResourceAsStream("config.yml")) {
-                    Files.copy(is, path);
-                }
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-        }
-
-        return path;
     }
 
     @Override

--- a/velocity/src/main/java/me/lucko/luckperms/velocity/VelocityClassPathAppender.java
+++ b/velocity/src/main/java/me/lucko/luckperms/velocity/VelocityClassPathAppender.java
@@ -23,23 +23,21 @@
  *  SOFTWARE.
  */
 
-package me.lucko.luckperms.bukkit;
+package me.lucko.luckperms.velocity;
 
-import me.lucko.luckperms.common.plugin.scheduler.AbstractJavaScheduler;
-import me.lucko.luckperms.common.plugin.scheduler.SchedulerAdapter;
+import me.lucko.luckperms.common.plugin.classpath.ClassPathAppender;
 
-import java.util.concurrent.Executor;
+import java.nio.file.Path;
 
-public class BukkitSchedulerAdapter extends AbstractJavaScheduler implements SchedulerAdapter {
-    private final Executor sync;
+public class VelocityClassPathAppender implements ClassPathAppender {
+    private final LPVelocityBootstrap bootstrap;
 
-    public BukkitSchedulerAdapter(LPBukkitBootstrap bootstrap) {
-        this.sync = r -> bootstrap.getServer().getScheduler().scheduleSyncDelayedTask(bootstrap.getLoader(), r);
+    public VelocityClassPathAppender(LPVelocityBootstrap bootstrap) {
+        this.bootstrap = bootstrap;
     }
 
     @Override
-    public Executor sync() {
-        return this.sync;
+    public void addJarToClasspath(Path file) {
+        this.bootstrap.getProxy().getPluginManager().addToClasspath(this.bootstrap, file);
     }
-
 }


### PR DESCRIPTION
#2853 

Fixes / works around the issues caused by the restrictions being put in "illegal access" reflection on closed Java modules, most notably on Java 16 where the existing solution used by LP no longer functions at all.

Still need to implement loaders for Bungee, Nukkit & Sponge.

Fabric and Velocity plugins do not need to use this new system as their APIs expose ways to add to the classpath at runtime.