### PR TITLE
Fix holder type and name on hover and click events in meta info entries

### DIFF
--- a/common/src/main/java/me/lucko/luckperms/common/locale/Message.java
+++ b/common/src/main/java/me/lucko/luckperms/common/locale/Message.java
@@ -47,6 +47,7 @@ import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import net.luckperms.api.context.Context;
 import net.luckperms.api.context.ContextSet;
+import net.luckperms.api.model.PermissionHolder.Identifier;
 import net.luckperms.api.node.ChatMetaType;
 import net.luckperms.api.node.Node;
 import net.luckperms.api.node.metadata.types.InheritanceOriginMetadata;
@@ -60,6 +61,7 @@ import java.time.Instant;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.OptionalInt;
 import java.util.stream.Collectors;
@@ -2237,7 +2239,14 @@ public interface Message {
                     .append(space())
                     .append(formatContextSetBracketed(node.getContexts(), empty()))
                     .apply(builder -> {
-                        String holderName = holder.getType() == HolderType.GROUP ? holder.getObjectName() : holder.getPlainDisplayName();
+                        InheritanceOriginMetadata origin = node.metadata(InheritanceOriginMetadata.KEY);
+                        String originName;
+                        if (origin.wasInherited(holder.getIdentifier())) {
+                            originName = origin.getOrigin().getName();
+                        } else {
+                            originName = holder.getPlainDisplayName();
+                        }
+                        HolderType originType = HolderType.valueOf(origin.getOrigin().getType().toUpperCase(Locale.ROOT));
                         boolean explicitGlobalContext = !holder.getPlugin().getConfiguration().getContextsFile().getDefaultContexts().isEmpty();
 
                         Component hover = join(newline(),
@@ -2251,10 +2260,10 @@ public interface Message {
                                 translatable()
                                         .key("luckperms.command.generic.chat-meta.info.click-to-remove")
                                         .color(GRAY)
-                                        .args(text(node.getMetaType().toString()), text(holderName))
+                                        .args(text(node.getMetaType().toString()), text(originName))
                         );
 
-                        String command = "/" + label + " " + NodeCommandFactory.undoCommand(node, holderName, holder.getType(), explicitGlobalContext);
+                        String command = "/" + label + " " + NodeCommandFactory.undoCommand(node, originName, originType, explicitGlobalContext);
 
                         builder.hoverEvent(HoverEvent.showText(hover));
                         builder.clickEvent(ClickEvent.suggestCommand(command));
@@ -2305,7 +2314,14 @@ public interface Message {
                     .append(space())
                     .append(formatContextSetBracketed(node.getContexts(), empty()))
                     .apply(builder -> {
-                        String holderName = holder.getType() == HolderType.GROUP ? holder.getObjectName() : holder.getPlainDisplayName();
+                        InheritanceOriginMetadata origin = node.metadata(InheritanceOriginMetadata.KEY);
+                        String originName;
+                        if (origin.wasInherited(holder.getIdentifier())) {
+                            originName = origin.getOrigin().getName();
+                        } else {
+                            originName = holder.getPlainDisplayName();
+                        }
+                        HolderType originType = HolderType.valueOf(origin.getOrigin().getType().toUpperCase(Locale.ROOT));
                         boolean explicitGlobalContext = !holder.getPlugin().getConfiguration().getContextsFile().getDefaultContexts().isEmpty();
 
                         Component hover = join(newline(),
@@ -2319,10 +2335,10 @@ public interface Message {
                                 translatable()
                                         .key("luckperms.command.generic.meta.info.click-to-remove")
                                         .color(GRAY)
-                                        .args(text(holderName))
+                                        .args(text(originName))
                         );
 
-                        String command = "/" + label + " " + NodeCommandFactory.undoCommand(node, holderName, holder.getType(), explicitGlobalContext);
+                        String command = "/" + label + " " + NodeCommandFactory.undoCommand(node, originName, originType, explicitGlobalContext);
 
                         builder.hoverEvent(HoverEvent.showText(hover));
                         builder.clickEvent(ClickEvent.suggestCommand(command));

--- a/common/src/main/java/me/lucko/luckperms/common/locale/Message.java
+++ b/common/src/main/java/me/lucko/luckperms/common/locale/Message.java
@@ -47,7 +47,6 @@ import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import net.luckperms.api.context.Context;
 import net.luckperms.api.context.ContextSet;
-import net.luckperms.api.model.PermissionHolder.Identifier;
 import net.luckperms.api.node.ChatMetaType;
 import net.luckperms.api.node.Node;
 import net.luckperms.api.node.metadata.types.InheritanceOriginMetadata;


### PR DESCRIPTION
Inherited meta nodes would show "Click to remove ... from \<holder\>" where \<holder\> would be the holder the command was run on, not the original meta node holder. This would often cause confusion when trying to delete the clicked node when inherited.

### Before

![image](https://user-images.githubusercontent.com/35617540/108664369-61932a00-74b1-11eb-9590-9acef255bcb8.png)


### After

![image](https://user-images.githubusercontent.com/35617540/108664282-2abd1400-74b1-11eb-8c1d-9793f59d582a.png)
