### PR TITLE
Safer way of getting GeneratedEventClass package

### DIFF
--- a/common/src/main/java/me/lucko/luckperms/common/event/gen/GeneratedEventClass.java
+++ b/common/src/main/java/me/lucko/luckperms/common/event/gen/GeneratedEventClass.java
@@ -106,7 +106,8 @@ public class GeneratedEventClass {
 
         // determine a generated class name of the event
         String eventClassSuffix = eventClass.getName().substring(LuckPermsEvent.class.getPackage().getName().length());
-        String generatedClassName = GeneratedEventClass.class.getPackage().getName() + eventClassSuffix;
+        String packageWithName = GeneratedEventClass.class.getName();
+        String generatedClassName = packageWithName.substring(0, packageWithName.lastIndexOf('.')) + eventClassSuffix;
 
         DynamicType.Builder<AbstractEvent> builder = new ByteBuddy(ClassFileVersion.JAVA_V8)
                 // create a subclass of AbstractEvent


### PR DESCRIPTION
When using Mohist 1.16 (and maybe other Forge+Bukkit hybrids), GeneratedEventClass.class.getPackage() is null for whatever reason.
This tiny change implements another way of getting the package and restores
compatibility with Mohist & Co.