### PR TITLE
Fabric - Compatibility with 1.17

### DIFF
--- a/fabric/src/main/java/me/lucko/luckperms/fabric/context/FabricPlayerCalculator.java
+++ b/fabric/src/main/java/me/lucko/luckperms/fabric/context/FabricPlayerCalculator.java
@@ -75,7 +75,8 @@ public class FabricPlayerCalculator implements ContextCalculator<ServerPlayerEnt
     @Override
     public void calculate(@NonNull ServerPlayerEntity target, @NonNull ContextConsumer consumer) {
         GameMode mode = target.interactionManager.getGameMode();
-        if (this.gamemode && mode != null && mode != GameMode.NOT_SET) {
+        final int GAME_MODE_NOT_SET = -1; // GameMode.NOT_SET with ID -1 was removed in 1.17
+        if (this.gamemode && mode != null && mode.getId() != GAME_MODE_NOT_SET) {
             consumer.accept(DefaultContextKeys.GAMEMODE_KEY, GAMEMODE_NAMER.name(mode));
         }
 


### PR DESCRIPTION
When testing with Fabric for 1.17-rc1, this exception occurred when a player joins:

```
[Server thread/WARN]: An exception was thrown by me.lucko.luckperms.fabric.context.FabricPlayerCalculator whilst
calculating the context of subject class_3222['****'/150, l='ServerLevel[world]', x=-33.75, y=68.00, z=-18.60]
java.lang.NoSuchFieldError: field_9218
        at me.lucko.luckperms.fabric.context.FabricPlayerCalculator.calculate(FabricPlayerCalculator.java:78) ~[LuckPerms-Fabric-5.3.42.jar:?]
        at me.lucko.luckperms.fabric.context.FabricPlayerCalculator.calculate(FabricPlayerCalculator.java:52) ~[LuckPerms-Fabric-5.3.42.jar:?]
        at me.lucko.luckperms.common.context.ContextManager.calculate(ContextManager.java:131) ~[LuckPerms-Fabric-5.3.42.jar:?]
```

This is because the enum value `GameMode.NOT_SET` was removed in 1.17.

The GameMode class now contains a new method to check for the id `-1` (see snippet below), but using that would break compatibility with 1.16. That's why I decided to hard code the `-1` ID.

```java
    @Nullable
    public static GameMode getOrNull(int id) {
        return id == -1 ? null : byId(id);
    }
```

I build LuckPerms from source with this patch applied, and confirmed that it works fine with 1.17-rc1 then.