### PR TITLE
Added support for using password files instead of just passwords

### DIFF
--- a/bukkit/src/main/resources/config.yml
+++ b/bukkit/src/main/resources/config.yml
@@ -105,6 +105,10 @@ data:
   username: root
   password: ''
 
+  # Optional. If the file path points to a file that can be loaded, use the text from
+  # the file as the password for the database instead of the password above
+  password-file: ''
+
   # These settings apply to the MySQL connection pool.
   # - The default values will be suitable for the majority of users.
   # - Do not change these settings unless you know what you're doing!

--- a/bungee/src/main/resources/config.yml
+++ b/bungee/src/main/resources/config.yml
@@ -102,6 +102,10 @@ data:
   username: root
   password: ''
 
+  # Optional. If the file path points to a file that can be loaded, use the text from
+  # the file as the password for the database instead of the password above
+  password-file: ''
+
   # These settings apply to the MySQL connection pool.
   # - The default values will be suitable for the majority of users.
   # - Do not change these settings unless you know what you're doing!

--- a/nukkit/src/main/resources/config.yml
+++ b/nukkit/src/main/resources/config.yml
@@ -105,6 +105,10 @@ data:
   username: root
   password: ''
 
+  # Optional. If the file path points to a file that can be loaded, use the text from
+  # the file as the password for the database instead of the password above
+  password-file: ''
+
   # These settings apply to the MySQL connection pool.
   # - The default values will be suitable for the majority of users.
   # - Do not change these settings unless you know what you're doing!

--- a/velocity/src/main/resources/config.yml
+++ b/velocity/src/main/resources/config.yml
@@ -95,6 +95,10 @@ data:
   username: root
   password: ''
 
+  # Optional. If the file path points to a file that can be loaded, use the text from
+  # the file as the password for the database instead of the password above
+  password-file: ''
+
   # These settings apply to the MySQL connection pool.
   # - The default values will be suitable for the majority of users.
   # - Do not change these settings unless you know what you're doing!


### PR DESCRIPTION
This pull requests provides the ability to specify a file with the password needed for connecting to a data source. This is useful for environments where it is desirable to open source or publish the configuration, but not possible to do currently due to the inclusion of a database password.

It will try to use the password file option whenever possible, but will gracefully fall back to using the original password option in the case of the file not being possible to read from.