### PR TITLE
Proper parsing for IPv6 addresses in configuration fields

### DIFF
--- a/common/src/main/java/me/lucko/luckperms/common/messaging/nats/NatsMessenger.java
+++ b/common/src/main/java/me/lucko/luckperms/common/messaging/nats/NatsMessenger.java
@@ -37,6 +37,7 @@ import io.nats.client.Options;
 import io.nats.client.Options.Builder;
 import me.lucko.luckperms.common.plugin.LuckPermsPlugin;
 import me.lucko.luckperms.common.util.Throwing;
+import me.lucko.luckperms.common.util.InetParser;
 import net.luckperms.api.messenger.IncomingMessageConsumer;
 import net.luckperms.api.messenger.Messenger;
 import net.luckperms.api.messenger.message.OutgoingMessage;
@@ -69,9 +70,9 @@ public class NatsMessenger implements Messenger {
     }
 
     public void init(String address, String username, String password, boolean ssl) {
-        String[] addressSplit = address.split(":");
-        String host = addressSplit[0];
-        int port = addressSplit.length > 1 ? Integer.parseInt(addressSplit[1]) : Options.DEFAULT_PORT;
+        InetParser.Address parsed = InetParser.parseAddress(address);
+        String host = parsed.address;
+        int port = parsed.port.map(Integer::parseInt).orElse(Options.DEFAULT_PORT);
 
         this.connection = createConnection(builder -> {
             builder.server("nats://" + host + ":" + port)

--- a/common/src/main/java/me/lucko/luckperms/common/messaging/redis/RedisMessenger.java
+++ b/common/src/main/java/me/lucko/luckperms/common/messaging/redis/RedisMessenger.java
@@ -26,6 +26,7 @@
 package me.lucko.luckperms.common.messaging.redis;
 
 import me.lucko.luckperms.common.plugin.LuckPermsPlugin;
+import me.lucko.luckperms.common.util.InetParser;
 import net.luckperms.api.messenger.IncomingMessageConsumer;
 import net.luckperms.api.messenger.Messenger;
 import net.luckperms.api.messenger.message.OutgoingMessage;
@@ -86,9 +87,10 @@ public class RedisMessenger implements Messenger {
     }
 
     private static HostAndPort parseAddress(String address) {
-        String[] addressSplit = address.split(":");
-        String host = addressSplit[0];
-        int port = addressSplit.length > 1 ? Integer.parseInt(addressSplit[1]) : Protocol.DEFAULT_PORT;
+        InetParser.Address parsed = InetParser.parseAddress(address);
+        String host = parsed.address;
+        int port = parsed.port.map(Integer::parseInt).orElse(Protocol.DEFAULT_PORT);
+
         return new HostAndPort(host, port);
     }
 

--- a/common/src/main/java/me/lucko/luckperms/common/storage/implementation/mongodb/MongoStorage.java
+++ b/common/src/main/java/me/lucko/luckperms/common/storage/implementation/mongodb/MongoStorage.java
@@ -60,6 +60,7 @@ import me.lucko.luckperms.common.storage.misc.NodeEntry;
 import me.lucko.luckperms.common.storage.misc.PlayerSaveResultImpl;
 import me.lucko.luckperms.common.storage.misc.StorageCredentials;
 import me.lucko.luckperms.common.util.Iterators;
+import me.lucko.luckperms.common.util.InetParser;
 import net.luckperms.api.actionlog.Action;
 import net.luckperms.api.context.Context;
 import net.luckperms.api.context.ContextSet;
@@ -129,9 +130,10 @@ public class MongoStorage implements StorageImplementation {
                 );
             }
 
-            String[] addressSplit = this.configuration.getAddress().split(":");
-            String host = addressSplit[0];
-            int port = addressSplit.length > 1 ? Integer.parseInt(addressSplit[1]) : 27017;
+            InetParser.Address parsed = InetParser.parseAddress(this.configuration.getAddress());
+            String host = parsed.address;
+            Integer port = parsed.port.map(Integer::parseInt).orElse(27017);
+
             ServerAddress address = new ServerAddress(host, port);
 
             if (credential == null) {

--- a/common/src/main/java/me/lucko/luckperms/common/storage/implementation/sql/connection/hikari/HikariConnectionFactory.java
+++ b/common/src/main/java/me/lucko/luckperms/common/storage/implementation/sql/connection/hikari/HikariConnectionFactory.java
@@ -33,6 +33,7 @@ import me.lucko.luckperms.common.plugin.logging.PluginLogger;
 import me.lucko.luckperms.common.storage.StorageMetadata;
 import me.lucko.luckperms.common.storage.implementation.sql.connection.ConnectionFactory;
 import me.lucko.luckperms.common.storage.misc.StorageCredentials;
+import me.lucko.luckperms.common.util.InetParser;
 
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -65,12 +66,12 @@ public abstract class HikariConnectionFactory implements ConnectionFactory {
      *
      * <p>Each driver does this slightly differently...</p>
      *
-     * @param config the hikari config
-     * @param address the database address
-     * @param port the database port
+     * @param config       the hikari config
+     * @param address      the database address
+     * @param port         the database port
      * @param databaseName the database name
-     * @param username the database username
-     * @param password the database password
+     * @param username     the database username
+     * @param password     the database password
      */
     protected abstract void configureDatabase(HikariConfig config, String address, String port, String databaseName, String username, String password);
 
@@ -87,7 +88,7 @@ public abstract class HikariConnectionFactory implements ConnectionFactory {
     /**
      * Sets the given connection properties onto the config.
      *
-     * @param config the hikari config
+     * @param config     the hikari config
      * @param properties the properties
      */
     protected void setProperties(HikariConfig config, Map<String, Object> properties) {
@@ -117,9 +118,9 @@ public abstract class HikariConnectionFactory implements ConnectionFactory {
         config.setPoolName("luckperms-hikari");
 
         // get the database info/credentials from the config file
-        String[] addressSplit = this.configuration.getAddress().split(":");
-        String address = addressSplit[0];
-        String port = addressSplit.length > 1 ? addressSplit[1] : defaultPort();
+        InetParser.Address parsed = InetParser.parseAddress(this.configuration.getAddress());
+        String address = parsed.address;
+        String port = parsed.port.orElse(defaultPort());
 
         // allow the implementation to configure the HikariConfig appropriately with these values
         try {

--- a/common/src/main/java/me/lucko/luckperms/common/util/InetParser.java
+++ b/common/src/main/java/me/lucko/luckperms/common/util/InetParser.java
@@ -1,0 +1,56 @@
+package me.lucko.luckperms.common.util;
+
+import java.util.Optional;
+
+public class InetParser {
+    public static class Address {
+        public String address;
+        public Optional<String> port;
+
+        @Override
+        public String toString() {
+            return port.map(p -> address + ":" + p).orElse(address);
+        }
+    }
+
+    public static Address parseAddress(String input) {
+        System.out.println("Input: " + input);
+        if (input == null || input.isEmpty()) {
+            throw new IllegalArgumentException("Empty address passed");
+        }
+
+        Address result = new Address();
+
+        if (input.startsWith("[")) {
+            // [addr]:port
+            int end = input.indexOf("]");
+
+            if (end == -1) {
+                throw new IllegalArgumentException("Invalid IPv6 address: terminator ']' is missing");
+            }
+
+            result.address = String.format("[%s]", input.substring(1, end));
+
+            if (end + 1 < input.length() && input.charAt(end + 1) == ':') {
+                result.port = Optional.of(input.substring(end + 2));
+            } else {
+                result.port = Optional.empty();
+            }
+        } else {
+            // IPv4/hostname
+            int colon = input.lastIndexOf(':');
+
+            if (colon != -1) {
+                result.address = input.substring(0, colon);
+                result.port = Optional.of(input.substring(colon + 1));
+            } else {
+                result.address = input;
+                result.port = Optional.empty();
+            }
+        }
+
+        System.out.println("Output parsed: " + result);
+
+        return result;
+    }
+}


### PR DESCRIPTION
I've added an InetParser class that correctly parses addresses and replaced all existing split-based parsing with it.

This fixes #3753.

## Things to review

When an IPv6 address is parsed, the InetParser.address property returns the host in the [IPv6] format instead of plain IPv6. Please check if this behavior is acceptable for all use cases. I confirm `Hikari` works on my personal servers.