### PR TITLE
Ensure that MessagingService is loaded after EventDispatcher initialization

### DIFF
--- a/common/src/main/java/me/lucko/luckperms/common/plugin/AbstractLuckPermsPlugin.java
+++ b/common/src/main/java/me/lucko/luckperms/common/plugin/AbstractLuckPermsPlugin.java
@@ -202,7 +202,6 @@ public abstract class AbstractLuckPermsPlugin implements LuckPermsPlugin {
 
         // initialise storage
         this.storage = storageFactory.getInstance();
-        this.messagingService = provideMessagingFactory().getInstance();
 
         // setup the update task buffer
         this.syncTaskBuffer = new SyncTask.Buffer(this);
@@ -238,6 +237,9 @@ public abstract class AbstractLuckPermsPlugin implements LuckPermsPlugin {
         getBootstrap().getScheduler().executeAsync(GeneratedEventClass::preGenerate);
         ApiRegistrationUtil.registerProvider(this.apiProvider);
         registerApiOnPlatform(this.apiProvider);
+
+        // register messaging service
+        this.messagingService = provideMessagingFactory().getInstance();
 
         // setup extension manager
         this.extensionManager = new SimpleExtensionManager(this);


### PR DESCRIPTION
Fix getEventDispatcher() npe.
```text
[Server thread/INFO]: [LuckPerms] Loading messaging service... [REDIS]
[luckperms-worker-4/WARN]: [LuckPerms] Unable to decode incoming messaging service message: 'xxxx'
java.lang.NullPointerException: Cannot invoke "me.lucko.luckperms.common.event.EventDispatcher.dispatchLogReceive(java.util.UUID, net.luckperms.api.actionlog.Action)" because the return value of "me.lucko.luckperms.common.plugin.LuckPermsPlugin.getEventDispatcher()" is null
	at me.lucko.luckperms.common.messaging.LuckPermsMessagingService.processIncomingMessage(LuckPermsMessagingService.java:289) ~[?:?]
	at me.lucko.luckperms.common.messaging.LuckPermsMessagingService.consumeIncomingMessageAsString0(LuckPermsMessagingService.java:236) ~[?:?]
	at me.lucko.luckperms.common.messaging.LuckPermsMessagingService.consumeIncomingMessageAsString(LuckPermsMessagingService.java:181) ~[?:?]
	at me.lucko.luckperms.common.messaging.redis.RedisMessenger$Subscription.onMessage(RedisMessenger.java:155) ~[?:?]
	at me.lucko.luckperms.common.messaging.redis.RedisMessenger$Subscription.onMessage(RedisMessenger.java:109) ~[?:?]
```