### PR TITLE
Enhance Hytale chat formatter with PlaceholderAPI integration

### DIFF
--- a/common/src/main/java/me/lucko/luckperms/common/config/ConfigKeys.java
+++ b/common/src/main/java/me/lucko/luckperms/common/config/ConfigKeys.java
@@ -758,7 +758,7 @@ public final class ConfigKeys {
     /**
      * If the chat formatter is enabled
      */
-    public static final ConfigKey<Boolean> CHAT_FORMATTER_ENABLED = booleanKey("chat-formatter.enabled", true);
+    public static final ConfigKey<Boolean> CHAT_FORMATTER_ENABLED = notReloadable(booleanKey("chat-formatter.enabled", true));
 
     /**
      * The chat formatter format string

--- a/hytale/build.gradle
+++ b/hytale/build.gradle
@@ -13,10 +13,13 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.7'
 
     compileOnly 'com.hypixel.hytale:Server:2026.01.24-6e2d4fc36'
+
+    compileOnly 'at.helpch:placeholderapi-hytale:1.0.6'
 }
 
 repositories {
     maven { url 'https://maven.hytale.com/release/' }
+    maven { url 'https://repo.helpch.at/releases/' }
 }
 
 shadowJar {

--- a/hytale/loader-with-deps/src/main/resources/manifest.json
+++ b/hytale/loader-with-deps/src/main/resources/manifest.json
@@ -7,7 +7,9 @@
   "Website": "https://luckperms.net",
   "ServerVersion": "*",
   "Dependencies": {},
-  "OptionalDependencies": {},
+  "OptionalDependencies": {
+    "HelpChat:PlaceholderAPI": ">= 1.0.2"
+  },
   "DisabledByDefault": false,
   "Main": "me.lucko.luckperms.hytale.loader.HytaleLoaderPlugin",
   "IncludesAssetPack": false

--- a/hytale/loader/src/main/resources/manifest.json
+++ b/hytale/loader/src/main/resources/manifest.json
@@ -7,7 +7,9 @@
   "Website": "https://luckperms.net",
   "ServerVersion": "*",
   "Dependencies": {},
-  "OptionalDependencies": {},
+  "OptionalDependencies": {
+    "HelpChat:PlaceholderAPI": ">= 1.0.2"
+  },
   "DisabledByDefault": false,
   "Main": "me.lucko.luckperms.hytale.loader.HytaleLoaderPlugin",
   "IncludesAssetPack": false

--- a/hytale/src/main/java/me/lucko/luckperms/hytale/LPHytalePlugin.java
+++ b/hytale/src/main/java/me/lucko/luckperms/hytale/LPHytalePlugin.java
@@ -50,11 +50,11 @@ import me.lucko.luckperms.common.plugin.util.AbstractConnectionListener;
 import me.lucko.luckperms.common.sender.Sender;
 import me.lucko.luckperms.hytale.calculator.HytaleCalculatorFactory;
 import me.lucko.luckperms.hytale.calculator.virtualgroups.VirtualGroupsMap;
-import me.lucko.luckperms.hytale.chat.LuckPermsChatFormatter;
 import me.lucko.luckperms.hytale.context.HytaleContextManager;
 import me.lucko.luckperms.hytale.context.HytalePlayerCalculator;
 import me.lucko.luckperms.hytale.listeners.HytaleConnectionListener;
 import me.lucko.luckperms.hytale.listeners.HytalePlatformListener;
+import me.lucko.luckperms.hytale.listeners.HytaleChatListener;
 import me.lucko.luckperms.hytale.service.LuckPermsPermissionProvider;
 import me.lucko.luckperms.hytale.service.PlayerVirtualGroupsMap;
 import net.luckperms.api.LuckPerms;
@@ -83,6 +83,7 @@ public class LPHytalePlugin extends AbstractLuckPermsPlugin {
     private PlayerVirtualGroupsMap playerVirtualGroupsMap;
     private VirtualGroupsMap virtualGroupsMap;
     private LuckPermsPermissionProvider permissionProvider;
+    private HytaleChatListener chatListener;
 
     public LPHytalePlugin(LPHytaleBootstrap bootstrap) {
         this.bootstrap = bootstrap;
@@ -205,8 +206,8 @@ public class LPHytalePlugin extends AbstractLuckPermsPlugin {
 
         // chat
         if (getConfiguration().get(ConfigKeys.CHAT_FORMATTER_ENABLED)) {
-            LuckPermsChatFormatter chatFormatter = new LuckPermsChatFormatter(this);
-            chatFormatter.register(this.bootstrap.getLoader().getEventRegistry());
+            this.chatListener = new HytaleChatListener(this);
+            this.chatListener.register(this.bootstrap.getLoader().getEventRegistry());
         }
 
         // general
@@ -236,7 +237,9 @@ public class LPHytalePlugin extends AbstractLuckPermsPlugin {
 
     @Override
     protected void performFinalSetup() {
-
+        if (this.chatListener != null) {
+            getApiProvider().getEventBus().subscribe(this.chatListener);
+        }
     }
 
     @Override

--- a/hytale/src/main/java/me/lucko/luckperms/hytale/chat/LuckPermsChatFormatter.java
+++ b/hytale/src/main/java/me/lucko/luckperms/hytale/chat/LuckPermsChatFormatter.java
@@ -25,78 +25,202 @@
 
 package me.lucko.luckperms.hytale.chat;
 
-import com.hypixel.hytale.event.EventRegistry;
 import com.hypixel.hytale.server.core.Message;
 import com.hypixel.hytale.server.core.event.events.player.PlayerChatEvent;
 import com.hypixel.hytale.server.core.universe.PlayerRef;
+import me.lucko.luckperms.common.cacheddata.type.MetaCache;
 import me.lucko.luckperms.common.config.ConfigKeys;
 import me.lucko.luckperms.common.model.User;
+import me.lucko.luckperms.common.verbose.event.CheckOrigin;
 import me.lucko.luckperms.hytale.HytaleSenderFactory;
 import me.lucko.luckperms.hytale.LPHytalePlugin;
+import net.kyori.adventure.pointer.Pointered;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
+import net.kyori.adventure.text.minimessage.Context;
 import net.kyori.adventure.text.minimessage.MiniMessage;
-import net.kyori.adventure.text.minimessage.tag.TagPattern;
+import net.kyori.adventure.text.minimessage.ParsingException;
+import net.kyori.adventure.text.minimessage.tag.Tag;
+import net.kyori.adventure.text.minimessage.tag.resolver.ArgumentQueue;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.jspecify.annotations.NonNull;
 
 public class LuckPermsChatFormatter implements PlayerChatEvent.Formatter {
     private final LPHytalePlugin plugin;
     private final String format;
+    private final MiniMessage mm;
 
     public LuckPermsChatFormatter(LPHytalePlugin plugin) {
         this.plugin = plugin;
-        this.format = plugin.getConfiguration().get(ConfigKeys.CHAT_FORMATTER_MESSAGE_FORMAT);
-    }
 
-    public void register(EventRegistry registry) {
-        registry.registerGlobal(PlayerChatEvent.class, this::onPlayerChat);
-    }
+        String format = plugin.getConfiguration().get(ConfigKeys.CHAT_FORMATTER_MESSAGE_FORMAT);
+        PlaceholderApiHook placeholderHook;
 
-    private void onPlayerChat(PlayerChatEvent e) {
-        e.setFormatter(this);
+        if (PlaceholderApiHook.containsPlaceholders(format)) {
+            this.format = PlaceholderApiHook.transformFormat(format);
+            placeholderHook = PlaceholderApiHook.init();
+            if (placeholderHook == null) {
+                plugin.getLogger().warn("Chat format contains PlaceholderAPI placeholders, but PlaceholderAPI is not loaded!");
+            }
+        } else {
+            this.format = format;
+            placeholderHook = null;
+        }
+
+        this.mm = MiniMessage.builder()
+                .editTags(tags -> {
+                    tags.resolver(new LuckPermsTagResolver(this.plugin));
+                    if (placeholderHook != null) {
+                        tags.resolver(new PlaceholderApiTagResolver(this.plugin, placeholderHook));
+                    }
+                })
+                .build();
     }
 
     @Override
     public @NonNull Message format(@NonNull PlayerRef playerRef, @NonNull String message) {
-        String username = playerRef.getUsername();
-        String prefix = "";
-        String suffix = "";
-
-        User user = this.plugin.getUserManager().getIfLoaded(playerRef.getUuid());
-        if (user != null) {
-            prefix = user.getCachedData().getMetaData().getPrefix();
-            if (prefix == null) {
-                prefix = "";
-            }
-            suffix = user.getCachedData().getMetaData().getSuffix();
-            if (suffix == null) {
-                suffix = "";
-            }
+        try {
+            Component component = this.mm.deserialize(
+                    this.format,
+                    new WrappedPlayerRef(playerRef),
+                    Placeholder.unparsed("username", playerRef.getUsername()),
+                    Placeholder.unparsed("message", message)
+            );
+            return HytaleSenderFactory.toHytaleMessage(component);
+        } catch (RuntimeException e) {
+            this.plugin.getLogger().warn("Failed to format chat message", e);
+            throw e;
         }
-
-        Component component = MiniMessage.miniMessage().deserialize(
-                this.format,
-                parse("prefix", prefix),
-                parse("suffix", suffix),
-                Placeholder.unparsed("username", username),
-                Placeholder.unparsed("message", message)
-        );
-        return HytaleSenderFactory.toHytaleMessage(component);
     }
 
-    private static TagResolver parse(@TagPattern String key, String value) {
-        boolean containsLegacyFormattingCharacter = value.indexOf(LegacyComponentSerializer.AMPERSAND_CHAR) != -1
-                || value.indexOf(LegacyComponentSerializer.SECTION_CHAR) != -1;
+    /** Empty tag **/
+    private static final Tag EMPTY = Tag.selfClosingInserting(Component.empty());
 
-        if (containsLegacyFormattingCharacter) {
-            TextComponent component = LegacyComponentSerializer.legacyAmpersand().deserialize(value);
-            return Placeholder.component(key, component);
-        } else {
-            return Placeholder.parsed(key, value);
+    /**
+     * A tag resolver for LuckPerms tags.
+     *
+     * @param plugin the plugin instance
+     */
+    private record LuckPermsTagResolver(LPHytalePlugin plugin) implements TagResolver {
+
+        @Override
+        public @Nullable Tag resolve(@NotNull String name, @NotNull ArgumentQueue arguments, @NotNull Context ctx) throws ParsingException {
+            if (!has(name)) {
+                return null;
+            }
+
+            PlayerRef playerRef = ctx.targetAsType(WrappedPlayerRef.class).playerRef();
+            User user = this.plugin.getUserManager().getIfLoaded(playerRef.getUuid());
+            if (user == null) {
+                return EMPTY;
+            }
+
+            MetaCache metaData = user.getCachedData().getMetaData();
+            return switch (name) {
+                case "prefix" -> {
+                    ensureNoArguments(name, arguments, ctx);
+                    String value = metaData.getPrefix(CheckOrigin.INTERNAL).result();
+                    yield parseFormattedText(value);
+                }
+                case "suffix" -> {
+                    ensureNoArguments(name, arguments, ctx);
+                    String value = metaData.getSuffix(CheckOrigin.INTERNAL).result();
+                    yield parseFormattedText(value);
+                }
+                case "meta" -> {
+                    String metaKey = arguments.popOr("Meta tag requires a 'meta key' argument").value();
+                    ensureNoArguments(name, arguments, ctx);
+
+                    String value = metaData.getMetaValue(metaKey, CheckOrigin.INTERNAL).result();
+                    yield parseFormattedText(value);
+                }
+                default -> null;
+            };
         }
+
+        @Override
+        public boolean has(@NotNull String name) {
+            return "prefix".equalsIgnoreCase(name) || "suffix".equalsIgnoreCase(name) || "meta".equalsIgnoreCase(name);
+        }
+    }
+
+    /**
+     * A tag resolver for PlaceholderAPI placeholders.
+     *
+     * @param plugin the plugin instance
+     * @param placeholderHook the PlaceholderAPI hook instance
+     */
+    private record PlaceholderApiTagResolver(LPHytalePlugin plugin, PlaceholderApiHook placeholderHook) implements TagResolver {
+
+        @Override
+        public @Nullable Tag resolve(@NotNull String name, @NotNull ArgumentQueue arguments, @NotNull Context ctx) throws ParsingException {
+            if (!has(name)) {
+                return null;
+            }
+
+            PlayerRef playerRef = ctx.targetAsType(WrappedPlayerRef.class).playerRef();
+            String placeholder = arguments.popOr("Placeholder tag requires a 'placeholder' argument").value();
+            ensureNoArguments(name, arguments, ctx);
+
+            String value;
+            try {
+                value = this.placeholderHook.resolvePlaceholder(playerRef, placeholder);
+            } catch (RuntimeException e) {
+                this.plugin.getLogger().warn("Failed to resolve PlaceholderAPI placeholder '" + placeholder + "'", e);
+                value = "";
+            }
+            return parseFormattedText(value);
+        }
+
+        @Override
+        public boolean has(@NotNull String name) {
+            return "papi".equalsIgnoreCase(name);
+        }
+    }
+
+    private static void ensureNoArguments(String name, ArgumentQueue arguments, Context ctx) {
+        if (arguments.hasNext()) {
+            throw ctx.newException("Tag '<" + name + ">' was given more arguments than required");
+        }
+    }
+
+    /**
+     * A wrapper for PlayerRef to be used as a pointer in the MiniMessage context.
+     */
+    private record WrappedPlayerRef(PlayerRef playerRef) implements Pointered { }
+
+    private static Tag parseFormattedText(String value) {
+        if (value == null || value.isEmpty()) {
+            return EMPTY;
+        }
+
+        char legacyChar = findLegacyColorCodes(value);
+        if (legacyChar != 0) {
+            TextComponent component = LegacyComponentSerializer.legacy(legacyChar).deserialize(value);
+            return Tag.inserting(component);
+        } else {
+            return Tag.preProcessParsed(value);
+        }
+    }
+
+    /**
+     * Checks if the input string contains any legacy color codes (either '&x' or '§x').
+     * If it does, it returns the character used for the color codes. If not, it returns 0.
+     */
+    private static char findLegacyColorCodes(String string) {
+        final char[] charArray = string.toCharArray();
+        for (int i = 0; i < charArray.length - 1; i++) {
+            if ((charArray[i] == LegacyComponentSerializer.AMPERSAND_CHAR
+                    || charArray[i] == LegacyComponentSerializer.SECTION_CHAR)
+                    && "0123456789AaBbCcDdEeFfKkLlMmNnOoRrXx".indexOf(charArray[i + 1]) > -1) {
+                return charArray[i];
+            }
+        }
+        return 0;
     }
 
 }

--- a/hytale/src/main/java/me/lucko/luckperms/hytale/chat/PlaceholderApiHook.java
+++ b/hytale/src/main/java/me/lucko/luckperms/hytale/chat/PlaceholderApiHook.java
@@ -1,0 +1,76 @@
+/*
+ * This file is part of LuckPerms, licensed under the MIT License.
+ *
+ *  Copyright (c) lucko (Luck) <luck@lucko.me>
+ *  Copyright (c) contributors
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ */
+
+package me.lucko.luckperms.hytale.chat;
+
+import com.hypixel.hytale.server.core.universe.PlayerRef;
+
+import java.util.regex.Pattern;
+
+/**
+ * Integration with PlaceholderAPI.
+ */
+public interface PlaceholderApiHook {
+
+    Pattern PERCENT_PLACEHOLDER_PATTERN = Pattern.compile("[%]([^%]+)[%]");
+    Pattern BRACKET_PLACEHOLDER_PATTERN = Pattern.compile("[{]([^{}]+)[}]");
+
+    /**
+     * Checks if the input string contains any placeholders.
+     *
+     * @param input the string to check
+     * @return true if the string contains placeholders, false otherwise
+     */
+    static boolean containsPlaceholders(String input) {
+        return PERCENT_PLACEHOLDER_PATTERN.matcher(input).find() || BRACKET_PLACEHOLDER_PATTERN.matcher(input).find();
+    }
+
+    /**
+     * Transforms the format string, replacing placeholders in {@code %placeholder%}
+     * or {@code {placeholder}} format with {@code <papi:'placeholder'>}.
+     *
+     * <p>This allows the placeholders to be resolved by the MiniMessage parser.</p>
+     *
+     * @param input the string to transform
+     * @return the transformed string
+     */
+    static String transformFormat(String input) {
+        input = PERCENT_PLACEHOLDER_PATTERN.matcher(input).replaceAll("<papi:'$1'>");
+        input = BRACKET_PLACEHOLDER_PATTERN.matcher(input).replaceAll("<papi:'$1'>");
+        return input;
+    }
+
+    static PlaceholderApiHook init() {
+        try {
+            Class.forName("at.helpch.placeholderapi.PlaceholderAPI");
+            return new PlaceholderApiHookImpl();
+        } catch (ClassNotFoundException e) {
+            return null;
+        }
+    }
+
+    String resolvePlaceholder(PlayerRef playerRef, String placeholder);
+
+}

--- a/hytale/src/main/java/me/lucko/luckperms/hytale/chat/PlaceholderApiHookImpl.java
+++ b/hytale/src/main/java/me/lucko/luckperms/hytale/chat/PlaceholderApiHookImpl.java
@@ -1,0 +1,38 @@
+/*
+ * This file is part of LuckPerms, licensed under the MIT License.
+ *
+ *  Copyright (c) lucko (Luck) <luck@lucko.me>
+ *  Copyright (c) contributors
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ */
+
+package me.lucko.luckperms.hytale.chat;
+
+import at.helpch.placeholderapi.PlaceholderAPI;
+import com.hypixel.hytale.server.core.universe.PlayerRef;
+
+public class PlaceholderApiHookImpl implements PlaceholderApiHook {
+
+    @Override
+    public String resolvePlaceholder(PlayerRef playerRef, String placeholder) {
+        return PlaceholderAPI.setPlaceholders(playerRef, "%" + placeholder + "%");
+    }
+
+}

--- a/hytale/src/main/java/me/lucko/luckperms/hytale/listeners/HytaleChatListener.java
+++ b/hytale/src/main/java/me/lucko/luckperms/hytale/listeners/HytaleChatListener.java
@@ -1,0 +1,62 @@
+/*
+ * This file is part of LuckPerms, licensed under the MIT License.
+ *
+ *  Copyright (c) lucko (Luck) <luck@lucko.me>
+ *  Copyright (c) contributors
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ */
+
+package me.lucko.luckperms.hytale.listeners;
+
+import com.hypixel.hytale.event.EventRegistry;
+import com.hypixel.hytale.server.core.event.events.player.PlayerChatEvent;
+import me.lucko.luckperms.common.event.LuckPermsEventListener;
+import me.lucko.luckperms.hytale.LPHytalePlugin;
+import me.lucko.luckperms.hytale.chat.LuckPermsChatFormatter;
+import net.luckperms.api.event.EventBus;
+import net.luckperms.api.event.sync.ConfigReloadEvent;
+
+public class HytaleChatListener implements LuckPermsEventListener {
+    private final LPHytalePlugin plugin;
+    private LuckPermsChatFormatter formatter;
+
+    public HytaleChatListener(LPHytalePlugin plugin) {
+        this.plugin = plugin;
+        this.formatter = new LuckPermsChatFormatter(plugin);
+    }
+
+    public void register(EventRegistry registry) {
+        registry.registerGlobal(PlayerChatEvent.class, this::onPlayerChat);
+    }
+
+    @Override
+    public void bind(EventBus bus) {
+        bus.subscribe(ConfigReloadEvent.class, this::onConfigReload);
+    }
+
+    private void onPlayerChat(PlayerChatEvent e) {
+        e.setFormatter(this.formatter);
+    }
+
+    private void onConfigReload(ConfigReloadEvent e) {
+        this.formatter = new LuckPermsChatFormatter(this.plugin);
+    }
+
+}

--- a/hytale/src/main/resources/config.yml
+++ b/hytale/src/main/resources/config.yml
@@ -62,13 +62,26 @@ use-server-uuid-cache: false
 # When enabled, LuckPerms formats the chat using the format defined below.
 # The following placeholders are supported:
 #
-# - <prefix>: The players prefix meta value
-# - <username>: The players username
-# - <suffix>: The players suffix meta value
-# - <message>: The actual chat message sent by the player
+# - Chat Message:
+#   => <username>       The players username
+#   => <message>        The actual chat message sent by the player
 #
-# The format string, as well as the prefix and suffix values support formatting using MiniMessage:
-#   https://docs.papermc.io/adventure/minimessage/
+# - LuckPerms:
+#   => <prefix>         The players prefix meta value
+#   => <suffix>         The players suffix meta value
+#   => <meta:META_KEY>  The players meta value for the given key
+#
+# - PlaceholderAPI:
+#   => %placeholder%    Any PlaceholderAPI placeholder. Relational placeholders are not supported.
+#
+# - MiniMessage:
+#   => <color>          Named colors
+#   => <#00ff00>        Hex colors
+#   => <bold>           Bold text
+#   => <italic>         Italic text
+#   ... many more. See for more info: https://docs.papermc.io/adventure/minimessage/format/
+#
+# MiniMessage formatting is also resolved in LuckPerms and PlaceholderAPI values.
 #
 chat-formatter:
 
@@ -76,6 +89,9 @@ chat-formatter:
   enabled: true
 
   # The format to use.
+  #
+  # - See above for the supported placeholders.
+  # - Can be reloaded using the '/lp reloadconfig' command.
   message-format: "<prefix><username><suffix>: <message>"
 
 


### PR DESCRIPTION
Enhances the built-in LuckPerms chat formatter with PlaceholderAPI integration.

I am currently not sure about whether this functionality belongs in LP or not.

Pros:

* Lack of chat formatting plugins on Hytale that support placeholders and complex formats - this will fill a gap, even if temporarily until other plugins catch up
* LuckPerms already bundles MiniMessage, which facilitates this nicely. The built-in Hytale `Message` API is very basic and doesn't have a MiniMessage equivalent format.
* We don't have to publish another plugin (but maybe this would ultimately make more sense?)

Cons:

* We have bucked the trend already (relative to LuckPerms for Minecraft platforms) by including a chat formatter on Hytale. Historically we have avoided doing this and left it to other plugins because the potential for scope creep is huge. This is another step in that direction.
* Very likely to result in increased support demand - bugs, questions, etc
* Doesn't (and will not) support relational placeholders
* Lots of placeholders will not work due to async nature of chat - see below

```
[2026/02/16 22:11:47   WARN]           [LuckPerms|P] Failed to resolve PlaceholderAPI placeholder 'player_world'
java.lang.IllegalStateException: Assert not in thread! Thread[#99,WorldThread - default,5,InnocuousForkJoinWorkerThreadGroup] but was in Thread[#89,ServerWorkerGroup - 3,5,InnocuousForkJoinWorkerThreadGroup]
	at com.hypixel.hytale.component.Store.assertThread(Store.java:2306)
	at com.hypixel.hytale.component.Store.getComponent(Store.java:1215)
	at at.helpch.papi.expansion.player.PlayerExpansion.onPlaceholderRequest(PlayerExpansion.java:60)
	at ThirdPartyPlugin//at.helpch.placeholderapi.replacer.CharsReplacer.apply(CharsReplacer.java:120)
	at ThirdPartyPlugin//at.helpch.placeholderapi.PlaceholderAPI.setPlaceholders(PlaceholderAPI.java:69)
	at me.lucko.luckperms.hytale.chat.PlaceholderApiHookImpl.resolvePlaceholder(PlaceholderApiHookImpl.java:35)
	at me.lucko.luckperms.hytale.chat.LuckPermsChatFormatter$PlaceholderApiTagResolver.resolve(LuckPermsChatFormatter.java:171)
	at me.lucko.luckperms.lib.adventure.text.minimessage.tag.resolver.SequentialTagResolver.resolve(SequentialTagResolver.java:48)
	at me.lucko.luckperms.lib.adventure.text.minimessage.MiniMessageParser.lambda$parseToTree$3(MiniMessageParser.java:184)
	at me.lucko.luckperms.lib.adventure.text.minimessage.internal.parser.match.StringResolvingMatchedTokenConsumer.accept(StringResolvingMatchedTokenConsumer.java:94)
	at me.lucko.luckperms.lib.adventure.text.minimessage.internal.parser.TokenParser.parseString(TokenParser.java:247)
	at me.lucko.luckperms.lib.adventure.text.minimessage.internal.parser.TokenParser.resolvePreProcessTags(TokenParser.java:112)
	at me.lucko.luckperms.lib.adventure.text.minimessage.MiniMessageParser.parseToTree(MiniMessageParser.java:195)
	at me.lucko.luckperms.lib.adventure.text.minimessage.MiniMessageParser.parseFormat(MiniMessageParser.java:209)
	at me.lucko.luckperms.lib.adventure.text.minimessage.MiniMessageImpl.deserialize(MiniMessageImpl.java:97)
	at me.lucko.luckperms.lib.adventure.text.minimessage.MiniMessage.deserialize(MiniMessage.java:197)
	at me.lucko.luckperms.hytale.chat.LuckPermsChatFormatter.format(LuckPermsChatFormatter.java:87)
	at com.hypixel.hytale.server.core.io.handlers.game.GamePacketHandler.lambda$handle$3(GamePacketHandler.java:417)
```

Opening this for reviews and to gather feedback on whether it is a good fit or not.